### PR TITLE
Add ERC to FAQ_en.html IRC clients

### DIFF
--- a/FAQ_en.html
+++ b/FAQ_en.html
@@ -68,6 +68,7 @@
 <li><a href="http://www.os-cillation.de/en/open-source-projekte/xfce-terminal/">Xfce Terminal</a></li>
 <li><a href="http://www.tenshu.net/p/terminator.html">Terminator</a></li>
 <li><a href="http://library.gnome.org/users/gnome-terminal/">GNOME Terminal</a></li>
+<li><a href="http://www.emacswiki.org/emacs/ERC">Emacs Relay Chat (ERC)</a></li>
 </ul>
 <p>And <a href="http://en.wikipedia.org/wiki/List_of_terminal_emulators">many many others</a>, so take your pick and find what works best for you.</p>
 <p>Those have no UTF-8 support:</p>


### PR DESCRIPTION
Include Emacs Relay Chat in the list of IRC clients for Flubox FAQ.

(This is my virgin GitHub pull request, so it's admittedly trivial.)