### PR TITLE
Update FAQ_en.html

### DIFF
--- a/FAQ_en.html
+++ b/FAQ_en.html
@@ -23,8 +23,8 @@
 </ul>
 <h3 id="which-version-of-fluxbox-should-i-run">Which version of Fluxbox should I run</h3>
 <p>The recommended fluxbox version is always the latest development version. It is the most stable available. Get it from <a href="http://fluxbox.org/download/"><a href="http://fluxbox.org/download">http://fluxbox.org/download</a></a>.</p>
-<p>You can learn how to <a href="build fluxbox from source" title="wikilink">build fluxbox from source</a> if you don't know how to do this.</p>
-<p>If you like to test new features or help hunting down some bugs you may think about the git version of fluxbox, which is the bleeding edge release. See <a href="build fluxbox from source #What_is_git_version_and_why_should_I_use_it.3F" title="wikilink">how to get and install git version</a></p>
+<p>You can learn how to <a href="Build_fluxbox_from_source.html">build fluxbox from source</a> if you don't know how to do this.</p>
+<p>If you like to test new features or help hunting down some bugs you may think about the git version of fluxbox, which is the bleeding edge release. See <a href="Build_fluxbox_from_source.html#what-is-git-version-and-why-should-i-use-it">how to get and install git version</a></p>
 <h3 id="why-do-people-say-that-stable-isnt-stable">Why do people say that 'stable' isnt stable</h3>
 <p>People used to say this because for a very long time the only &quot;official&quot; stable version was 1.1 and it wasn't touched for over 2 years. Now this is not true. The latest offical stable is version 1.3.1 and it is considered very stable. The latest development version is also considered to be a very stable version. Go and get it from <a href="http://fluxbox.org/download/"><a href="http://fluxbox.org/download/">http://fluxbox.org/download/</a></a></p>
 <h3 id="what-are-the-main-differences-between-fluxbox-and-box">What are the main differences between Fluxbox and *box</h3>
@@ -130,7 +130,7 @@
 <p><code> fluxbox -i</code></p>
 <p>and look for <strong>XPM</strong> for xpm icon support and <strong>IMLIB2</strong> for png support. The syntax is simple, for example:</p>
 <p><code> [exec] (firefox) {firefox} </code></usr/share/pixmaps/firefox.xpm></p>
-<p>If you have an icon named <strong>firefox.xpm</strong> in your /usr/share/pixmaps dir then that will put the icon in the menu. For more help with your menu see the <a href="editing the menu" title="wikilink">menu edition howto</a>.</p>
+<p>If you have an icon named <strong>firefox.xpm</strong> in your /usr/share/pixmaps dir then that will put the icon in the menu. For more help with your menu see the <a href="Editing_the_menu.html">menu edition howto</a>.</p>
 <h3 id="how-do-i-make-menu-icons-bigger">How do I make menu icons bigger</h3>
 <p>Take a look at the style you are currently using</p>
 <p><code> grep -i stylef ~/.fluxbox/init</code></p>
@@ -140,9 +140,9 @@
 <h3 id="how-do-i-generate-a-menu">How do I generate a menu</h3>
 <p>If you have started fluxbox but have an empty menu, try using the command</p>
 <p><code> fluxbox-generate_menu -h</code></p>
-<p>Also see <a href="Editing the menu" title="wikilink">this howto</a>.</p>
+<p>Also see <a href="Editing_the_menu.html">this howto</a>.</p>
 <h3 id="on-fedora-my-menu-is-overwritten-on-every-startup-how-do-i-fix-it">On Fedora My menu is overwritten on every Startup, How do I fix it</h3>
-<p>For some reason the Fedora guys decided to make the default <a href="editing the startup file" title="wikilink">startup file</a> run their custom menu generator command. To prevent your changes from being over ridden open your startup file and look for</p>
+<p>For some reason the Fedora guys decided to make the default <a href="Editing_the_startup_file.html">startup file</a> run their custom menu generator command. To prevent your changes from being over ridden open your startup file and look for</p>
 <p><code> if [ -x /usr/bin/fluxbox-xdg-menu ]; then</code><br /><code>      /usr/bin/fluxbox-xdg-menu --with-icons &amp;</code><br /><code> fi</code></p>
 <p>Just remove this from the startup file and your menu changes will no longer get lost on each startup.</p>
 <h2 id="transparency">Transparency</h2>
@@ -165,10 +165,10 @@
 <li><a href="http://sourceforge.net/projects/idesk/">idesk</a></li>
 <li><a href="http://www.oroborus.org/">DeskLaunch</a></li>
 </ul>
-<p>See the howto for <a href="idesk" title="wikilink">idesk</a> and for <a href="fbdesk" title="wikilink">fbdesk</a> for info on getting these setup.</p>
+<p>See the howto for <a href="Idesk.html">idesk</a> and for <a href="Fbdesk.html">fbdesk</a> for info on getting these setup.</p>
 <p>You could also use a file manager like rox-filer or pcmafm for the icons, but they are not as flexible as the ones above and may cause some problems.</p>
 <h3 id="i-upgraded-to-fluxbox-0.9.14-or-newer-from-0.9.13-or-older-and-now-my-fonts-dont-look-right.-why">I upgraded to fluxbox 0.9.14 or newer from 0.9.13 or older and now my fonts dont look right. Why?</h3>
-<p>Since the 0.9.14 release the use of fonts changed a bit. Check the <a href="Change font" title="wikilink">font howto</a>.</p>
+<p>Since the 0.9.14 release the use of fonts changed a bit. Check the <a href="Change_font.html">font howto</a>.</p>
 <h3 id="i-keep-hearing-about-these-artwiz-fonts-what-gives">I keep hearing about these Artwiz fonts! What gives?</h3>
 <p>Try reading the Artwiz/Fluxbox Guide.</p>
 <p>If you like the Artwiz fonts, but don't like the way they look in terminals, consider checking out the 'LFP' Fontpack. There are two sets of fonts there, the LFP-Fixed width (good for terminals), and LFP Variable-width (good for other things).</p>
@@ -180,16 +180,16 @@
 <h3 id="is-there-a-way-to-have-slit-dockapps-be-in-a-certain-order">Is there a way to have slit dockapps be in a certain order?</h3>
 <p>As of 0.1.10, YES!</p>
 <h3 id="how-do-i-set-my-background">How do I set my background</h3>
-<p>The command to use is <strong>fbsetbg</strong> To find out how to use it either consult its man page, or take a look at this <a href="Howto_set_the_background" title="wikilink">howto</a>.</p>
+<p>The command to use is <strong>fbsetbg</strong> To find out how to use it either consult its man page, or take a look at this <a href="Howto_set_the_background.html">howto</a>.</p>
 <h3 id="how-do-i-change-the-resolution">How do I change the resolution</h3>
 <p>Run the command:</p>
 <p><code> xrandr -s </code><size><code>x</code><size></p>
 <p>where <size> would be a value like 1280x1024. For this to work, it must be a valid value in your X config.</p>
-<p>You should also read <a href="change resolution" title="wikilink">the detailed page</a>.</p>
+<p>You should also read <a href="Change_resolution.html">the detailed page</a>.</p>
 <h3 id="how-can-i-group-apps">How can I group apps</h3>
-<p>Look at <a href="Editing the apps file#Grouping_apps_via_the_apps_file" title="wikilink">the grouping howTo</a> to learn about it.</p>
+<p>Look at <a href="Editing_the_apps_file.html#grouping-apps-via-the-apps-file">the grouping howTo</a> to learn about it.</p>
 <h3 id="is-there-a-list-of-supported-platforms-platform-success-reports">Is there a list of supported platforms / platform success reports</h3>
-<p>Yes there is. Please see <a href="supported platform success reports" title="wikilink">supported platform success reports</a>.</p>
+<p>There doesn't seem to be one any more but looks like there used to be a file called "Supported_platform_success_reports.html".</p>
 <h3 id="how-do-i-change-the-height-of-my-toolbar">How do I change the height of my toolbar</h3>
 <p>Open your ~/.fluxbox/init and search for the line</p>
 <p><code>session.screen0.toolbar.height</code></p>
@@ -214,7 +214,7 @@
 <p>All window managers that offer outline moving need to enforce the same rule so that the display doesn't become messy with rectange fragments during or after the move operation. If you find one that doesn't, let us know :)</p>
 <p>The author believes that applications such as XMMS whose primary function is not graphical ought to be able to continue to operate without the display updating (mplayer has a good excuse to pause). However, this behaviour is not under the control of the Fluxbox developers - you should talk to XMMS people to see if they can make it continue playing even without display updates (though I imagine this may also be a difficult problem).</p>
 <h3 id="how-do-i-launch-apps-automatically-on-fluxbox-startup">How do I launch apps automatically on Fluxbox startup?</h3>
-<p>You can either use the <a href="Editing the startup file" title="wikilink">startup file</a>, or set up your <a href=".xinitrc" title="wikilink">.xinitrc</a> file.</p>
+<p>You can either use the <a href="Editing_the_startup_file.html">startup file</a>, or set up your .xinitrc file.</p>
 <h3 id="i-make-changes-to-my-.fluxboxinit-but-they-are-getting-overwritten.">I make changes to my ~/.fluxbox/init, but they are getting overwritten.</h3>
 <p>This is a bug in versions of fluxbox prior to 0.1.8-bugfix2. Please upgrade to the latest version/bugfix before reporting this as a bug.</p>
 <h3 id="can-i-use-my-existing-.blackboxrc-for-fluxbox">Can I use my existing .blackboxrc for Fluxbox?</h3>
@@ -285,7 +285,7 @@
 <h3 id="how-do-i-work-the-bots-in-the-fluxbox-chatroom">How do I work the bots in the fluxbox chatroom</h3>
 <p>The main bot in the room is <em>fbot</em>. When he is on holiday or what ever, <em>computer</em> is there as a backup. Both bots have very similar syntax. To ask them a question address them:</p>
 <p><code> fbot: styles?</code></p>
-<p>For more information please see <a href="how to work the bots" title="wikilink">how to work the bots</a>.</p>
+<p>For more information please see <a href="How_to_work_the_bots.html">how to work the bots</a>.</p>
 <h3 id="why-arent-there-any-ops-in-the-fluxbox-chatroom">Why arent there any OP's in the fluxbox chatroom</h3>
 <p>We have a very mature room and almost never need to have someone in the room to moderate it. Keep in mind there are several OPs in the room, they just dont wear their badges.</p>
 <h3 id="what-is-this-fluxbox-chitchat-room-for-and-why-am-i-being-told-to-go-there">What is this fluxbox-chitchat room for and why am I being told to go there</h3>


### PR DESCRIPTION
Fix all "wikilink" links to refer to the existing static html file, if available. Remove two links not found: 217: ".xinitrc" and 191: "Supported platform success reports" (added comment).