### PR TITLE
swapped out domain names to use github provided domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-fluxbox-wiki.org
+fluxbox-wiki.github.io

--- a/FAQ_en.html
+++ b/FAQ_en.html
@@ -231,7 +231,7 @@
 <p><code># -- THEME AUTO-WRITTEN DO NOT EDIT</code><br /><code>include &quot;/home/yourname/.themes/Murrina-Olive/gtk-2.0/gtkrc&quot;</code><br /><code>include &quot;/home/yourname/.gtkrc-2.0.mine&quot;</code><br /><code># -- THEME AUTO-WRITTEN DO NOT EDIT</code></p>
 <p>Create ~/.gtkrc-2.0.mine:</p>
 <p><code>gtk-icon-theme-name = &quot;Tango&quot;</code><br /><code>gtk-font-name = &quot;sans 8&quot;</code><br /><code>gtk-toolbar-icon-size = GTK_ICON_SIZE_SMALL_TOOLBAR</code><br /><code>gtk-toolbar-style = GTK_TOOLBAR_ICONS</code></p>
-<p>See the <a href="http://fluxbox-wiki.org/index.php/Howto_gtk_themes">GTK howto</a>.</p>
+<p>See the <a href="http://fluxbox-wiki.github.io/index.php/Howto_gtk_themes">GTK howto</a>.</p>
 <p>Alternatively, if you have GNOME installed run gnome-settings-daemon when Fluxbox starts, eg. put this into your ~/.xinitrc</p>
 <p><code># load this to have gtk2 apps look ok</code><br /><code>GSDPID=`pidof gnome-settings-daemon`</code><br /><code>if [  &quot;x$GSDPID&quot; == &quot;x&quot; ]; then</code><br /><code>  gnome-settings-daemon &amp;</code><br /><code>fi</code></p>
 <p>If the above code fails to work, try switching the line</p>

--- a/about.html
+++ b/about.html
@@ -12,8 +12,8 @@
     <title>Fluxbox Wiki</title>
 
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
   </head>
 
   <body>
@@ -21,21 +21,21 @@
  <div class="container theme-showcase" role="main">
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li class="active"><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li class="active"><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -62,7 +62,7 @@
  
  	<div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/de/Auflösung_anpassen.html
+++ b/category/howtos/de/Auflösung_anpassen.html
@@ -12,8 +12,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -27,21 +27,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -142,7 +142,7 @@ EndSection</pre>
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/de/Computer_herunterfahren.html
+++ b/category/howtos/de/Computer_herunterfahren.html
@@ -12,8 +12,8 @@
   <title>Fluxbox Wiki</title>
 <!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
   <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-  <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+  <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 <!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 <!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 </head>
@@ -25,21 +25,21 @@
 <!-- BEGINNING: NAV MENU -->
 <div class="header">
   <ul class="nav nav-pills pull-right" style="font-size:15px">
-    <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-    <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-    <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
     <li><a href="#searchfield">Search</a></li>
     <li class="dropdown, active">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
         </ul>
     </li>
     <li> 
@@ -104,7 +104,7 @@
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
   <div class="footer">
     <br>
-    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       <br>
   </div>
 

--- a/category/howtos/de/Coredumps_erstellen.html
+++ b/category/howtos/de/Coredumps_erstellen.html
@@ -11,8 +11,8 @@
   <title>Fluxbox Wiki</title>
 <!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
   <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-  <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+  <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 <!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 <!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 </head>
@@ -24,21 +24,21 @@
 <!-- BEGINNING: NAV MENU -->
 <div class="header">
   <ul class="nav nav-pills pull-right" style="font-size:15px">
-    <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-    <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-    <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
     <li><a href="#searchfield">Search</a></li>
     <li class="dropdown, active">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
         </ul>
     </li>
     <li> 
@@ -96,7 +96,7 @@
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
   <div class="footer">
     <br>
-    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       <br>
   </div>
 

--- a/category/howtos/de/Crashhandling_und_Wiederherstellung.html
+++ b/category/howtos/de/Crashhandling_und_Wiederherstellung.html
@@ -11,8 +11,8 @@
   <title>Fluxbox Wiki</title>
 <!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
   <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-  <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+  <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 <!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 <!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 </head>
@@ -24,21 +24,21 @@
 <!-- BEGINNING: NAV MENU -->
 <div class="header">
   <ul class="nav nav-pills pull-right" style="font-size:15px">
-    <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-    <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-    <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
     <li><a href="#searchfield">Search</a></li>
     <li class="dropdown, active">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
         </ul>
     </li>
     <li> 
@@ -101,7 +101,7 @@ xcompmgr &amp;
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
   <div class="footer">
     <br>
-    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       <br>
   </div>
 

--- a/category/howtos/de/Fluxbox_Menu_Editor_(de).html
+++ b/category/howtos/de/Fluxbox_Menu_Editor_(de).html
@@ -11,8 +11,8 @@
   <title>Fluxbox Wiki</title>
 <!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
   <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-  <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+  <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 <!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 <!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 </head>
@@ -24,21 +24,21 @@
 <!-- BEGINNING: NAV MENU -->
 <div class="header">
   <ul class="nav nav-pills pull-right" style="font-size:15px">
-    <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-    <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-    <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
     <li><a href="#searchfield">Search</a></li>
     <li class="dropdown, active">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
         </ul>
     </li>
     <li> 
@@ -84,7 +84,7 @@
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
   <div class="footer">
     <br>
-    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       <br>
   </div>
 

--- a/category/howtos/de/Fluxbox_in_KDM-GDM_einbinden.html
+++ b/category/howtos/de/Fluxbox_in_KDM-GDM_einbinden.html
@@ -11,8 +11,8 @@
   <title>Fluxbox Wiki</title>
 <!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
   <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-  <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+  <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 <!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 <!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 </head>
@@ -24,21 +24,21 @@
 <!-- BEGINNING: NAV MENU -->
 <div class="header">
   <ul class="nav nav-pills pull-right" style="font-size:15px">
-    <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-    <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-    <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
     <li><a href="#searchfield">Search</a></li>
     <li class="dropdown, active">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
         </ul>
     </li>
     <li> 
@@ -87,7 +87,7 @@ Type=Application</pre>
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
   <div class="footer">
     <br>
-    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       <br>
   </div>
 

--- a/category/howtos/de/Fluxbox_in_XDM_einbinden.html
+++ b/category/howtos/de/Fluxbox_in_XDM_einbinden.html
@@ -11,8 +11,8 @@
   <title>Fluxbox Wiki</title>
 <!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
   <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-  <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+  <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 <!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 <!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 </head>
@@ -24,21 +24,21 @@
 <!-- BEGINNING: NAV MENU -->
 <div class="header">
   <ul class="nav nav-pills pull-right" style="font-size:15px">
-    <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-    <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-    <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
     <li><a href="#searchfield">Search</a></li>
     <li class="dropdown, active">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
         </ul>
     </li>
     <li> 
@@ -75,7 +75,7 @@
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
   <div class="footer">
     <br>
-    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       <br>
   </div>
 

--- a/category/howtos/de/Howto_Lockscreen.html
+++ b/category/howtos/de/Howto_Lockscreen.html
@@ -11,8 +11,8 @@
   <title>Fluxbox Wiki</title>
 <!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
   <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-  <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+  <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 <!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 <!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 </head>
@@ -24,21 +24,21 @@
 <!-- BEGINNING: NAV MENU -->
 <div class="header">
   <ul class="nav nav-pills pull-right" style="font-size:15px">
-    <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-    <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-    <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
     <li><a href="#searchfield">Search</a></li>
     <li class="dropdown, active">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
         </ul>
     </li>
     <li> 
@@ -77,7 +77,7 @@
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
   <div class="footer">
     <br>
-    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       <br>
   </div>
 

--- a/category/howtos/de/Howto_anpassen_der_apps_file.html
+++ b/category/howtos/de/Howto_anpassen_der_apps_file.html
@@ -11,8 +11,8 @@
   <title>Fluxbox Wiki</title>
 <!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
   <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-  <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+  <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 <!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 <!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 </head>
@@ -24,21 +24,21 @@
 <!-- BEGINNING: NAV MENU -->
 <div class="header">
   <ul class="nav nav-pills pull-right" style="font-size:15px">
-    <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-    <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-    <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
     <li><a href="#searchfield">Search</a></li>
     <li class="dropdown, active">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
         </ul>
     </li>
     <li> 
@@ -147,7 +147,7 @@
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
   <div class="footer">
     <br>
-    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       <br>
   </div>
 

--- a/category/howtos/de/Howto_anpassen_der_keys_file.html
+++ b/category/howtos/de/Howto_anpassen_der_keys_file.html
@@ -11,8 +11,8 @@
   <title>Fluxbox Wiki</title>
 <!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
   <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-  <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+  <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 <!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 <!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 </head>
@@ -24,21 +24,21 @@
 <!-- BEGINNING: NAV MENU -->
 <div class="header">
   <ul class="nav nav-pills pull-right" style="font-size:15px">
-    <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-    <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-    <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
     <li><a href="#searchfield">Search</a></li>
     <li class="dropdown, active">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
         </ul>
     </li>
     <li> 
@@ -247,7 +247,7 @@ BindKey &lt;key&gt;&lt;value&gt;: &lt;action&gt;   #Weist eine Taste einem Be
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
   <div class="footer">
     <br>
-    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       <br>
   </div>
 

--- a/category/howtos/de/Howto_anpassen_der_startup_file.html
+++ b/category/howtos/de/Howto_anpassen_der_startup_file.html
@@ -11,8 +11,8 @@
   <title>Fluxbox Wiki</title>
 <!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
   <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-  <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+  <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 <!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 <!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 </head>
@@ -24,21 +24,21 @@
 <!-- BEGINNING: NAV MENU -->
 <div class="header">
   <ul class="nav nav-pills pull-right" style="font-size:15px">
-    <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-    <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-    <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
     <li><a href="#searchfield">Search</a></li>
     <li class="dropdown, active">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
         </ul>
     </li>
     <li> 
@@ -121,7 +121,7 @@ wait $fbpid</pre>
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
   <div class="footer">
     <br>
-    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       <br>
   </div>
 

--- a/category/howtos/de/Howto_entfernen_der_Fensterdekoration.html
+++ b/category/howtos/de/Howto_entfernen_der_Fensterdekoration.html
@@ -11,8 +11,8 @@
   <title>Fluxbox Wiki</title>
 <!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
   <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-  <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+  <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 <!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 <!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 </head>
@@ -24,21 +24,21 @@
 <!-- BEGINNING: NAV MENU -->
 <div class="header">
   <ul class="nav nav-pills pull-right" style="font-size:15px">
-    <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-    <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-    <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
     <li><a href="#searchfield">Search</a></li>
     <li class="dropdown, active">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
         </ul>
     </li>
     <li> 
@@ -115,7 +115,7 @@ Zur Aktivierung muss die Konfiguration neu geladen werden, siehe analog dazu unt
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
   <div class="footer">
     <br>
-    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       <br>
   </div>
 

--- a/category/howtos/de/Howto_keymodes.html
+++ b/category/howtos/de/Howto_keymodes.html
@@ -11,8 +11,8 @@
   <title>Fluxbox Wiki</title>
 <!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
   <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-  <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+  <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 <!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 <!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 </head>
@@ -24,21 +24,21 @@
 <!-- BEGINNING: NAV MENU -->
 <div class="header">
   <ul class="nav nav-pills pull-right" style="font-size:15px">
-    <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-    <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-    <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+    <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
     <li><a href="#searchfield">Search</a></li>
     <li class="dropdown, active">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
         <ul class="dropdown-menu" role="menu">
-          <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-          <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+          <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
         </ul>
     </li>
     <li> 
@@ -122,7 +122,7 @@ Mod1 x                      :KeyMode XnestMode</pre>
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
   <div class="footer">
     <br>
-    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       <br>
   </div>
 

--- a/category/howtos/de/Howto_nur_rahmen_anzeigen_lassen.html
+++ b/category/howtos/de/Howto_nur_rahmen_anzeigen_lassen.html
@@ -17,7 +17,7 @@
 <p>Anschliessend fügt man folgende Zeilen ein:</p>
 <p><code>  [app] (.*)</code><br /><code>     [Deco]    {BORDER}</code><br /><code>  [end]</code></p>
 <p>Nach einem Neustart zeigt Fluxbox nur noch einen Rahmen um die Fenster an (wenn das gewählte Farbschema einen anzeigt) Farbe und Breite des Rahmens können angepasst werden,</p>
-<p>Entweder Global (unabhängig vom Farbschema) <a href="http://fluxbox-wiki.org/index.php/Howto_style_overlay">overlay file</a> oder separat in jedem Farbschema.</p>
+<p>Entweder Global (unabhängig vom Farbschema) <a href="http://fluxbox-wiki.github.io/index.php/Howto_style_overlay">overlay file</a> oder separat in jedem Farbschema.</p>
 <p>Folgende Zeilen passen den Rahmen an:</p>
 <p><code>  window.borderWidth:   </code><int><br /><code>  window.borderColor:   color (Bsp. #009900, black, rgb:00/64/00)</code></p>
 <h2 id="rahmen-und-externe-tabs-anzeigen-lassen">Rahmen und externe Tabs anzeigen lassen</h2>

--- a/category/howtos/de/index.html
+++ b/category/howtos/de/index.html
@@ -11,8 +11,8 @@
     <title>Fluxbox Wiki</title>
 
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
   </head>
 
   <body>
@@ -20,21 +20,21 @@
  <div class="container theme-showcase" role="main">
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -301,7 +301,7 @@
  
  	<div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
     

--- a/category/howtos/en/Borderless_windows.html
+++ b/category/howtos/en/Borderless_windows.html
@@ -10,8 +10,8 @@
 		<title>Fluxbox Wiki - Borderless Windows</title>
 		<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
 		<link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-		<link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-		<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+		<link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+		<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 		<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 		<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 	</head>
@@ -20,21 +20,21 @@
 			<!-- BEGINNING: NAV MENU -->
 			<div class="header">
 				<ul class="nav nav-pills pull-right" style="font-size:15px">
-					<li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-					<li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-					<li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+					<li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+					<li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+					<li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
 					<li><a href="#searchfield">Search</a></li>
 					<li class="dropdown, active">
 						<a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
 						<ul class="dropdown-menu" role="menu">
-							<li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
 						</ul>
 					</li>
 					<li>
@@ -72,7 +72,7 @@
 		<!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->
 		<div class="footer">
 			<br>
-			<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+			<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
 			<br>
 		</div>
 

--- a/category/howtos/en/Build_fluxbox_from_source.html
+++ b/category/howtos/en/Build_fluxbox_from_source.html
@@ -48,7 +48,7 @@
 <p>Git version of Fluxbox is the latest development version available for testing. So if you want to try bleeding edge features, help hunting bugs or create a custom patches, this is what you should use.</p>
 <h3 id="getting-the-git-version-and-installing-it">Getting the git version and installing it</h3>
 <p>You need <a href="http://git.or.cz/">git</a>, automake-tools and autoconf-tools to be installed.</p>
-<p>First please read-up on git usage <a href="http://fluxbox-wiki.org/index.php/Git_-_using">here</a></p>
+<p>First please read-up on git usage <a href="http://fluxbox-wiki.github.io/index.php/Git_-_using">here</a></p>
 <p>To get the sources and prepare for compilation you need to type:</p>
 <p><code>$ git clone </code><a href="git://git.fluxbox.org/fluxbox.git"><code>git://git.fluxbox.org/fluxbox.git</code></a><code> &amp;&amp; cd fluxbox &amp;&amp; ./autogen.sh</code></p>
 <p>After this you can go the usual way:</p>

--- a/category/howtos/en/Comment_out_rootcommands.html
+++ b/category/howtos/en/Comment_out_rootcommands.html
@@ -11,7 +11,7 @@
   <![endif]-->
 </head>
 <body>
-<p>If, for example, you have installed the <a href="http://web.archive.org/web/20071014003020/http://distro.ibiblio.org/pub/linux/distributions/gentoo/distfiles/commonbox-styles-extra-0.2.tar.bz2">commonbox-extra</a> styles from gentoo portage you will have many styles that contain a <a href="http://fluxbox-wiki.org/index.php?title=Howto_set_the_background#Setting_the_Wallpaper_on_Startup.2C_another_way">rootCommand</a> and they will set the background for you. I personally hate that and like to decide what I think looks best with a style.</p>
+<p>If, for example, you have installed the <a href="http://web.archive.org/web/20071014003020/http://distro.ibiblio.org/pub/linux/distributions/gentoo/distfiles/commonbox-styles-extra-0.2.tar.bz2">commonbox-extra</a> styles from gentoo portage you will have many styles that contain a <a href="http://fluxbox-wiki.github.io/index.php?title=Howto_set_the_background#Setting_the_Wallpaper_on_Startup.2C_another_way">rootCommand</a> and they will set the background for you. I personally hate that and like to decide what I think looks best with a style.</p>
 <p>A simple sed command will fix this up, move to the directory where you installed the styles and run:</p>
 <p><code> $ sed -i '/^rootCommand/s|^|!|' *</code></p>
 <p><a href="/category/howtos/en/index.html">Category:English howtos</a></p>

--- a/category/howtos/en/Configuration_files.html
+++ b/category/howtos/en/Configuration_files.html
@@ -32,27 +32,27 @@
  -rw-r--r-- windowmenu</code></pre>
 <p>Each file and directory has a very specific function.</p>
 <h3 id="backgrounds-pixmaps-e-styles">backgrounds, pixmaps e styles</h3>
-<p>In these three directories are commonly included icons for each element of the RootMenu, wallpapers and themes for Fluxbox. Commonly because this is only a convention, if properly configured Fluxbox can get a theme, an icon and a <a href="http://fluxbox-wiki.org/index.php?title=Howto_set_the_background">background</a> from any location on disk.</p>
+<p>In these three directories are commonly included icons for each element of the RootMenu, wallpapers and themes for Fluxbox. Commonly because this is only a convention, if properly configured Fluxbox can get a theme, an icon and a <a href="http://fluxbox-wiki.github.io/index.php?title=Howto_set_the_background">background</a> from any location on disk.</p>
 <h3 id="apps">apps</h3>
-<p><a href="http://fluxbox-wiki.org/index.php?title=Editing_the_apps_file">It</a> contains configurations for individual applications or window decorations such as, size, position, etc., as well as the automatic grouping (<a href="Tabs" title="wikilink">Tabs</a>).</p>
+<p><a href="http://fluxbox-wiki.github.io/index.php?title=Editing_the_apps_file">It</a> contains configurations for individual applications or window decorations such as, size, position, etc., as well as the automatic grouping (<a href="Tabs" title="wikilink">Tabs</a>).</p>
 <h3 id="fbrun_history">fbrun_history</h3>
 <p>A text file that contains the fbrun's command history, a tool available to the user that on many window manager is called &quot;Run ...&quot;. Useful for running a program with special parameters without having to use the terminal.</p>
 <h3 id="init">init</h3>
-<p>This <a href="http://fluxbox-wiki.org/index.php?title=Editing_the_init_file">file</a> is the most important, is where all the configuration parameters of Fluxbox are defined. When the window manager starts, it reads the content immediately to determine the parameters which must be started and the paths of the other configuration files.</p>
+<p>This <a href="http://fluxbox-wiki.github.io/index.php?title=Editing_the_init_file">file</a> is the most important, is where all the configuration parameters of Fluxbox are defined. When the window manager starts, it reads the content immediately to determine the parameters which must be started and the paths of the other configuration files.</p>
 <h3 id="keys">keys</h3>
-<p>Where actions are associated with the <a href="http://fluxbox-wiki.org/index.php?title=Keyboard_shortcuts">keyboard</a>, one of the qualities of Fluxbox is the ability to manage it entirely without a mouse using a wide and complex range of commands.</p>
+<p>Where actions are associated with the <a href="http://fluxbox-wiki.github.io/index.php?title=Keyboard_shortcuts">keyboard</a>, one of the qualities of Fluxbox is the ability to manage it entirely without a mouse using a wide and complex range of commands.</p>
 <h3 id="lastwallpaper">lastwallpaper</h3>
 <p>A file where the last string used to set the desktop background through fbsetbg or fbsetroot is stored, and that will be called automatically at startup.</p>
 <h3 id="menu">menu</h3>
-<p>The configuration file for <a href="http://fluxbox-wiki.org/index.php?title=Editing_the_menu">RootMenu</a>, the one that contains application you can run from and items to configure Fluxbox.</p>
+<p>The configuration file for <a href="http://fluxbox-wiki.github.io/index.php?title=Editing_the_menu">RootMenu</a>, the one that contains application you can run from and items to configure Fluxbox.</p>
 <h3 id="overlay">overlay</h3>
-<p><a href="http://fluxbox-wiki.org/index.php?title=Overlay">Here</a> you can make changes to the styles in a comprehensive manner and without having to touch every single theme.</p>
+<p><a href="http://fluxbox-wiki.github.io/index.php?title=Overlay">Here</a> you can make changes to the styles in a comprehensive manner and without having to touch every single theme.</p>
 <h3 id="slitlist">slitlist</h3>
-<p>Save the placement order in the <a href="http://fluxbox-wiki.org/index.php?title=FAQ#What_is_the_slit">slit</a> of the various applications loaded when you start Fluxbox.</p>
+<p>Save the placement order in the <a href="http://fluxbox-wiki.github.io/index.php?title=FAQ#What_is_the_slit">slit</a> of the various applications loaded when you start Fluxbox.</p>
 <h3 id="startup">startup</h3>
-<p>Each line of this file contains a command that is launched when you start Fluxbox. Useful for executing applications at <a href="http://fluxbox-wiki.org/index.php?title=Editing_the_startup_file">startup</a>.</p>
+<p>Each line of this file contains a command that is launched when you start Fluxbox. Useful for executing applications at <a href="http://fluxbox-wiki.github.io/index.php?title=Editing_the_startup_file">startup</a>.</p>
 <h3 id="windowmenu">windowmenu</h3>
-<p>The <a href="http://fluxbox-wiki.org/index.php?title=Editing_the_windowmenu">windowmenu</a> configuration file, the one that pops up with the right click on the titlebar and contains various commands to manage the window and the &quot;Remember&quot; menu to store the <a href="http://fluxbox-wiki.org/index.php?title=Editing_the_apps_file">apps</a> file the main aspects of a window.</p>
+<p>The <a href="http://fluxbox-wiki.github.io/index.php?title=Editing_the_windowmenu">windowmenu</a> configuration file, the one that pops up with the right click on the titlebar and contains various commands to manage the window and the &quot;Remember&quot; menu to store the <a href="http://fluxbox-wiki.github.io/index.php?title=Editing_the_apps_file">apps</a> file the main aspects of a window.</p>
 <p><a href="/category/howtos/en/index.html">Category:English howtos</a></p>
 </body>
 </html>

--- a/category/howtos/en/Editing_the_apps_file.html
+++ b/category/howtos/en/Editing_the_apps_file.html
@@ -21,7 +21,7 @@
 <li>restart fluxbox</li>
 <li>chmod 744 ~/.fluxbox/apps</li>
 </ul>
-<p>In order to obtain a skeleton configuration with the right atoms (name, class, role) for the application, pick up a random entry from the Remember submenu in the <a href="http://fluxbox-wiki.org/index.php?title=Editing_the_windowmenu">windowmenu</a>, then edit the <code>~/.fluxbox/apps</code> as you need.</p>
+<p>In order to obtain a skeleton configuration with the right atoms (name, class, role) for the application, pick up a random entry from the Remember submenu in the <a href="http://fluxbox-wiki.github.io/index.php?title=Editing_the_windowmenu">windowmenu</a>, then edit the <code>~/.fluxbox/apps</code> as you need.</p>
 <p>You can also find atoms by executing</p>
 <p><code>  $ xprop WM_CLASS | xmessage -file - -center</code></p>
 <p>and clicking onto the desired window:</p>

--- a/category/howtos/en/Editing_the_menu.html
+++ b/category/howtos/en/Editing_the_menu.html
@@ -45,7 +45,7 @@
 <p><code>[wallpapers] (directory) {command}</code><br /><code>   This allows you to list your backgrounds. This tag is built in to use </code><br /><code>   fbsetbg(1) and allows you to simply click on an image to set your </code><br /><code>   wallpaper. See? Fluxbox makes it easy… This item can also be hacked to</code><br /><code>   perform a command over directory content (it doesn't dive in subdirs,</code><br /><code>   it's a hack). For instance, to choose between playlists</code><br /><code>   [wallpapers] (~/Music/Playlists) {xmms} will perfectly work.</code></p>
 <p><code>[workspaces] (label)</code><br /><code>   This tells Fluxbox to insert a link to the workspaces menu directly into </code><br /><code>   your menu. This is handy for those users who can't access the workspace </code><br /><code>   menu directly (e.g. if you don't have a 3 button mouse, it is rather hard </code><br /><code>   to middle click to show the workspace menu).</code></p>
 <h3 id="i-want-some-kind-of-gui-for-this">I want some kind of GUI for this</h3>
-<p>Long story short. Use <a href="http://fluxbox-wiki.org/index.php?title=FluxMenu">fluxMenu</a>. It is old but should work just fine. Or <a href="http://fluxbox-wiki.org/index.php?title=Fluxbox_Menu_Editor_(en)">Fluxbox Menu Editor (FME)</a></p>
+<p>Long story short. Use <a href="http://fluxbox-wiki.github.io/index.php?title=FluxMenu">fluxMenu</a>. It is old but should work just fine. Or <a href="http://fluxbox-wiki.github.io/index.php?title=Fluxbox_Menu_Editor_(en)">Fluxbox Menu Editor (FME)</a></p>
 <p><a href="/category/howtos/en/index.html">Category:English howtos</a></p>
 </body>
 </html>

--- a/category/howtos/en/How_to_work_the_bots-Factoids.html
+++ b/category/howtos/en/How_to_work_the_bots-Factoids.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <h3 id="fbots-factoids">fbot's factoids</h3>
-<p>Please note that some of them are here for historical purposes and no longer work or they have ancient informations.<br />Check <a href="http://fluxbox-wiki.org/index.php?title=How_to_work_the_bots">how he works</a>.</p>
+<p>Please note that some of them are here for historical purposes and no longer work or they have ancient informations.<br />Check <a href="http://fluxbox-wiki.github.io/index.php?title=How_to_work_the_bots">how he works</a>.</p>
 <p><strong>0.1.14</strong><br />That version is old and unmaintained. We strongly suggest to upgrade. Please get the version from the topic. I repeat: 0.1.14 is UNMAINTAINED !</p>
 <p><strong>0114</strong><br />That version is old and unmaintained. We strongly suggest to upgrade. Please get the version from the topic. I repeat: 0.1.14 is UNMAINTAINED !</p>
 <p><strong>1.0</strong><br />out now, sure its an rc right now but its out <a href="http://old.fluxbox.org/version-0.9.php">http://old.fluxbox.org/version-0.9.php</a></p>
@@ -39,14 +39,14 @@
 <p><strong>arrows</strong><br />To disable the &quot;&lt; &gt;&quot; arrows in the toolbar edit ~/.fluxbox/init and remove from &quot;session.screen0.toolbar.tools:&quot; what you don't want (prevworkspace,nextworkspace,prevwindow,nextwindow)</p>
 <p><strong>artwiz</strong><br />The artwiz fonts homepage, with all the latest info, can be found at <a href="http://artwizaleczapka.sourceforge.net">http://artwizaleczapka.sourceforge.net</a>. For full iso-8859-1 charset support, try <a href="http://artwiz-latin1.sf.net">http://artwiz-latin1.sf.net</a></p>
 <p><strong>asenchi</strong><br />the guy with the masterplan.</p>
-<p><strong>ask</strong><br />just ask your question, dont ask to ask or check this page <a href="http://fluxbox-wiki.org/index.php/How_to_get_help_in_irc">http://fluxbox-wiki.org/index.php/How_to_get_help_in_irc</a></p>
-<p><strong>aterm</strong><br />aterm is most peoples favourite term. install the package from your distro. here is a nice aterm config-file: <a href="http://fluxbox-wiki.org/index.php?title=Xdefaults_setup">http://fluxbox-wiki.org/index.php?title=Xdefaults_setup</a></p>
+<p><strong>ask</strong><br />just ask your question, dont ask to ask or check this page <a href="http://fluxbox-wiki.github.io/index.php/How_to_get_help_in_irc">http://fluxbox-wiki.github.io/index.php/How_to_get_help_in_irc</a></p>
+<p><strong>aterm</strong><br />aterm is most peoples favourite term. install the package from your distro. here is a nice aterm config-file: <a href="http://fluxbox-wiki.github.io/index.php?title=Xdefaults_setup">http://fluxbox-wiki.github.io/index.php?title=Xdefaults_setup</a></p>
 <p><strong>autogen</strong><br />the script you have to run if you want to build fluxbox from cvs. You need automake, autoconf and libtool for this.</p>
 <p><strong>autogrouping</strong><br />to autogroup apps in fluxbox use the ~/.fluxbox/groups file</p>
 <p><strong>awake</strong><br />yes, i am here&lt;=or=&gt;<reply> most of the time, <who>&lt;=or=&gt;<reply> of course, i am here to serve you&lt;=or=&gt;ow, i had a lousy night ... too much beer .. and then the fine looking applegirl</p>
 <p><strong>awaynick</strong><br />If you want to know why it's not a good idea to make your nick indicating you're away, then please read this here: <a href="http://sackheads.org/~bnaylor/spew/away_msgs.html">http://sackheads.org/~bnaylor/spew/away_msgs.html</a></p>
-<p><strong>apps</strong><br />read all about the mystic `apps' file in the fluxbox manpage, section &quot;APPLICATIONS SETTINGS&quot; or at <a href="http://fluxbox-wiki.org/index.php/Howto_edit_the_apps_file">http://fluxbox-wiki.org/index.php/Howto_edit_the_apps_file</a> . Basically, it allows you to define the state of applications when they are started and make them automatically group using regular expression matching</p>
-<p><strong>background</strong><br />rootCommand was removed from styles in version 0.9.15; you should now use the &quot;background&quot; option, which is explained at <a href="http://fluxbox-wiki.org/index.php/Howto_set_the_background">http://fluxbox-wiki.org/index.php/Howto_set_the_background</a></p>
+<p><strong>apps</strong><br />read all about the mystic `apps' file in the fluxbox manpage, section &quot;APPLICATIONS SETTINGS&quot; or at <a href="http://fluxbox-wiki.github.io/index.php/Howto_edit_the_apps_file">http://fluxbox-wiki.github.io/index.php/Howto_edit_the_apps_file</a> . Basically, it allows you to define the state of applications when they are started and make them automatically group using regular expression matching</p>
+<p><strong>background</strong><br />rootCommand was removed from styles in version 0.9.15; you should now use the &quot;background&quot; option, which is explained at <a href="http://fluxbox-wiki.github.io/index.php/Howto_set_the_background">http://fluxbox-wiki.github.io/index.php/Howto_set_the_background</a></p>
 <p><strong>backgroundbuddy</strong><br />the autmatic-wallpaper-rotation daemon, written in perl. it allows one to have different wallpapers on each workspace. check out: <a href="http://fluxspace.sourceforge.net">http://fluxspace.sourceforge.net</a></p>
 <p><strong>backgrounds</strong><br />ask me for 'wallpapers'</p>
 <p><strong>ban</strong><br /><action> sets mode +b <who>!*@*</p>
@@ -58,9 +58,9 @@
 <p><strong>bbpager</strong><br />you most likely want to make a symlink from .fluxbox/init to .blackboxrc</p>
 <p><strong>beer</strong><br />yum yum.</p>
 <p><strong>beli</strong><br />the celtic god of lightning and healing and also provides some unoffical slackware packages (see slackware)</p>
-<p><strong>beryl</strong><br />compiz/beryl are window managers, and so is fluxbox, so you can't use them together. For more about why, see <a href="http://fluxbox-wiki.org/index.php/Faqs#Can_I_use_fluxbox_or_parts_of_it_with_XGL.2FCompiz.2FBeryl.3F">http://fluxbox-wiki.org/index.php/Faqs#Can_I_use_fluxbox_or_parts_of_it_with_XGL.2FCompiz.2FBeryl.3F</a></p>
+<p><strong>beryl</strong><br />compiz/beryl are window managers, and so is fluxbox, so you can't use them together. For more about why, see <a href="http://fluxbox-wiki.github.io/index.php/Faqs#Can_I_use_fluxbox_or_parts_of_it_with_XGL.2FCompiz.2FBeryl.3F">http://fluxbox-wiki.github.io/index.php/Faqs#Can_I_use_fluxbox_or_parts_of_it_with_XGL.2FCompiz.2FBeryl.3F</a></p>
 <p><strong>bfh</strong><br />a bfh is your best tool, its known as a big fuggin hammer</p>
-<p><strong>bg wiki</strong><br />having trouble with setting the background or getting transparency to work? check this out: <a href="http://fluxbox-wiki.org/index.php/Howto_set_the_background">http://fluxbox-wiki.org/index.php/Howto_set_the_background</a></p>
+<p><strong>bg wiki</strong><br />having trouble with setting the background or getting transparency to work? check this out: <a href="http://fluxbox-wiki.github.io/index.php/Howto_set_the_background">http://fluxbox-wiki.github.io/index.php/Howto_set_the_background</a></p>
 <p><strong>bionik</strong><br />a great stylist, he also uploads his themes to <a href="http://www.fluxmod.org">http://www.fluxmod.org</a></p>
 <p><strong>bird</strong><br />fried please</p>
 <p><strong>blackbox</strong><br />what differs fluxbox from blackbox is that it just adds a bunch of useless shit</p>
@@ -71,7 +71,7 @@
 <p><strong>bobbens</strong><br />Ol' MacBobbens had a renderfarm...EE-II-EE-II-OOH!</p>
 <p><strong>bold</strong><br />to use bold fonts, use lucidasans-10:bold for example</p>
 <p><strong>boogeymen</strong><br />yes, i ll save you from the boogeymen, my child. lay your head down and sleep well.</p>
-<p><strong>borderless</strong><br />to get rid of borders, titlebars, etc., add an entry to ~/.fluxbox/apps -- see man fluxbox-apps (section SETTINGS) or <a href="http://fluxbox-wiki.org/index.php/Borderless_windows">http://fluxbox-wiki.org/index.php/Borderless_windows</a></p>
+<p><strong>borderless</strong><br />to get rid of borders, titlebars, etc., add an entry to ~/.fluxbox/apps -- see man fluxbox-apps (section SETTINGS) or <a href="http://fluxbox-wiki.github.io/index.php/Borderless_windows">http://fluxbox-wiki.github.io/index.php/Borderless_windows</a></p>
 <p><strong>bot</strong><br />Im not a bot, Im a real boy</p>
 <p><strong>botbeer</strong><br />yum yum</p>
 <p><strong>botsnack</strong><br />I pretend to work, and they pretend to pay me.</p>
@@ -88,10 +88,10 @@
 <p><strong>coffee</strong><br />do you want some, <who>?&lt;=or=&gt;<reply> drink tea, its healthier, <who>!</p>
 <p><strong>color</strong><br /><a href="http://www.colorschemer.com/online.html">http://www.colorschemer.com/online.html</a></p>
 <p><strong>color codes</strong><br />for supported human-readable color codes, check /usr/X11R6/lib/X11/rgb.txt</p>
-<p><strong>compiz</strong><br />compiz and fluxbox are both window managers, and X only allows one window manager at any time, so they cannot be used together. For more information, see <a href="http://fluxbox-wiki.org/index.php/Faqs#Can_I_use_fluxbox_or_parts_of_it_with_XGL.2FCompiz.2FBeryl.3F">http://fluxbox-wiki.org/index.php/Faqs#Can_I_use_fluxbox_or_parts_of_it_with_XGL.2FCompiz.2FBeryl.3F</a></p>
+<p><strong>compiz</strong><br />compiz and fluxbox are both window managers, and X only allows one window manager at any time, so they cannot be used together. For more information, see <a href="http://fluxbox-wiki.github.io/index.php/Faqs#Can_I_use_fluxbox_or_parts_of_it_with_XGL.2FCompiz.2FBeryl.3F">http://fluxbox-wiki.github.io/index.php/Faqs#Can_I_use_fluxbox_or_parts_of_it_with_XGL.2FCompiz.2FBeryl.3F</a></p>
 <p><strong>composite</strong><br />the new xorg6.8 supports eyecandy, uberfancy composite extension .. which is marked as experimental. so dont complain if it breaks some things (eg slit, layers, dockapps ..). disable it, problems should disappear. ignore this advice ... well, now you are on your own. :)</p>
 <p><strong>conky</strong><br />Conky is an advanced, highly configurable system monitor for X <a href="http://conky.sf.net">http://conky.sf.net</a></p>
-<p><strong>coredump</strong><br />To learn how to setup fluxbox to provide a core dump please visit <a href="http://fluxbox-wiki.org/index.php/Howto_coredump">http://fluxbox-wiki.org/index.php/Howto_coredump</a></p>
+<p><strong>coredump</strong><br />To learn how to setup fluxbox to provide a core dump please visit <a href="http://fluxbox-wiki.github.io/index.php/Howto_coredump">http://fluxbox-wiki.github.io/index.php/Howto_coredump</a></p>
 <p><strong>cvs</strong><br />we are using subversion now for versioncontrol. check svn.</p>
 <p><strong>cvsdevel</strong><br />checkout: echo -n &quot;username: &quot;; read username; cvs -qz3 -d :ext:${username}@cvs.fluxbox.sourceforge.net:/cvsroot/fluxbox co fluxbox &amp;&amp; cd fluxbox &amp;&amp; ./autogen.sh</p>
 <p><strong>cvsfix</strong><br />sf.net CVS changed. Change any references from cvs.fluxbox.sourceforge.net to cvs.sourceforge.net</p>
@@ -104,12 +104,12 @@
 <p><strong>debug</strong><br />check <a href="http://wiki.fluxbox.org/index.php/Coredump">http://wiki.fluxbox.org/index.php/Coredump</a></p>
 <p><strong>deco</strong><br />to get decorationless windows add this line to your ~/.fluxbox/keys: &quot;mod1 t :toggledecor&quot;, reload the config and then press alt-t. for more permanent ways, see ,borderless</p>
 <p><strong>decomask</strong><br />the (strange) looking number for deco in the apps-file is a binary mask, bits are for: titlebar, handle, border, iconify, minimise, close, menu, sticky, shade, tab, enabled. use a good calculator to enter a binary mask and get a hex-number which represents the state on wants.</p>
-<p><strong>decor</strong><br />to get decorationless windows add this line to your ~/.fluxbox/keys: &quot;mod1 t :toggledecor&quot;, reload the config and then press alt-t. for more permanent ways, see ,borderless or <a href="http://fluxbox-wiki.org/index.php/Borderless_windows">http://fluxbox-wiki.org/index.php/Borderless_windows</a></p>
+<p><strong>decor</strong><br />to get decorationless windows add this line to your ~/.fluxbox/keys: &quot;mod1 t :toggledecor&quot;, reload the config and then press alt-t. for more permanent ways, see ,borderless or <a href="http://fluxbox-wiki.github.io/index.php/Borderless_windows">http://fluxbox-wiki.github.io/index.php/Borderless_windows</a></p>
 <p><strong>devel</strong><br />The latest fluxbox development release is 0.9.14 (the one you should get!)</p>
 <p><strong>devel-archive</strong><br />available at <a href="http://sourceforge.net/mailarchive/forum.php?forum=fluxbox-devel">http://sourceforge.net/mailarchive/forum.php?forum=fluxbox-devel</a></p>
 <p><strong>developers</strong><br />The developers are mainly fluxgen, Rathnor, ak|ra and _markt getting incredible support from Han (script-kungfoo), and innumerable other geeks :) all over the world.</p>
 <p><strong>devfaq</strong><br />read faqs to devel-version of fluxbox here: <a href="http://old.fluxbox.org/docs/en/faq-dev.php">http://old.fluxbox.org/docs/en/faq-dev.php</a></p>
-<p><strong>devs</strong><br />check out <a href="http://fluxbox-wiki.org/index.php/Faqs#Who_are_the_developers">http://fluxbox-wiki.org/index.php/Faqs#Who_are_the_developers</a></p>
+<p><strong>devs</strong><br />check out <a href="http://fluxbox-wiki.github.io/index.php/Faqs#Who_are_the_developers">http://fluxbox-wiki.github.io/index.php/Faqs#Who_are_the_developers</a></p>
 <p><strong>die</strong><br /><who> i am not dead, <who>!</p>
 <p><strong>dinet</strong><br />strange</p>
 <p><strong>distro</strong><br />please state the information about your distro/os. makes it a lot easier to give proper recommendations.</p>
@@ -134,27 +134,27 @@
 <p><strong>euro</strong><br />Online Money converter: <a href="http://www.xe.com/ucc/">http://www.xe.com/ucc/</a></p>
 <p><strong>evil</strong><br />that's me &gt;}:D</p>
 <p><strong>ewmh</strong><br />EWMH stands for Extended Window Manager Hints. It is a specification above the ICCCM for interacting with window managers. Find it at <a href="http://standards.freedesktop.org/wm-spec/latest/">http://standards.freedesktop.org/wm-spec/latest/</a></p>
-<p><strong>experimental</strong><br />Have a look at <a href="http://fluxbox-wiki.org/index.php/Experimental">http://fluxbox-wiki.org/index.php/Experimental</a> for experimental patches and extensions to fluxbox.</p>
-<p><strong>eyecandy?</strong><br /><a href="http://fluxbox-wiki.org/index.php/Howto_add_eye_candy">http://fluxbox-wiki.org/index.php/Howto_add_eye_candy</a></p>
-<p><strong>faq</strong><br />frequently asked questions are at: <a href="http://fluxbox-wiki.org/index.php?title=Faqs">http://fluxbox-wiki.org/index.php?title=Faqs</a></p>
+<p><strong>experimental</strong><br />Have a look at <a href="http://fluxbox-wiki.github.io/index.php/Experimental">http://fluxbox-wiki.github.io/index.php/Experimental</a> for experimental patches and extensions to fluxbox.</p>
+<p><strong>eyecandy?</strong><br /><a href="http://fluxbox-wiki.github.io/index.php/Howto_add_eye_candy">http://fluxbox-wiki.github.io/index.php/Howto_add_eye_candy</a></p>
+<p><strong>faq</strong><br />frequently asked questions are at: <a href="http://fluxbox-wiki.github.io/index.php?title=Faqs">http://fluxbox-wiki.github.io/index.php?title=Faqs</a></p>
 <p><strong>faqdev</strong><br />read faqs to dev-version of fluxbox here: <a href="http://old.fluxbox.org/docs/en/faq-dev.php">http://old.fluxbox.org/docs/en/faq-dev.php</a></p>
-<p><strong>faqs</strong><br />frequently asked questions are at: <a href="http://fluxbox-wiki.org/index.php/Faqs">http://fluxbox-wiki.org/index.php/Faqs</a></p>
+<p><strong>faqs</strong><br />frequently asked questions are at: <a href="http://fluxbox-wiki.github.io/index.php/Faqs">http://fluxbox-wiki.github.io/index.php/Faqs</a></p>
 <p><strong>favourite color</strong><br />ermm .. i like blue alot, kinda deep blue ... *hint*</p>
-<p><strong>fbdesk</strong><br />fbdesk plops icons on your desktop, url is <a href="http://fluxbox-wiki.org/index.php?title=Fbdesk">http://fluxbox-wiki.org/index.php?title=Fbdesk</a></p>
+<p><strong>fbdesk</strong><br />fbdesk plops icons on your desktop, url is <a href="http://fluxbox-wiki.github.io/index.php?title=Fbdesk">http://fluxbox-wiki.github.io/index.php?title=Fbdesk</a></p>
 <p><strong>fbgm</strong><br />a script to generate menu-files, you can always download the latest version here: <a href="http://git.fluxbox.org/fluxbox.git/tree/util/fluxbox-generate_menu.in">http://git.fluxbox.org/fluxbox.git/tree/util/fluxbox-generate_menu.in</a> ; install -m755 fluxbox-generate_menu.in /usr/local/bin/fluxbox-generate_menu</p>
 <p><strong>fbot</strong><br />that's me :)</p>
 <p><strong>fbpager</strong><br />Get fbpager from <a href="http://old.fluxbox.org/fbpager/">http://old.fluxbox.org/fbpager/</a></p>
 <p><strong>fbprocmenu</strong><br />fbprocmenu lets view and manipulate running processes from your fluxbox menu : <a href="http://www.gentoo-wiki.info/Fluxbox#fbprocmenu">http://www.gentoo-wiki.info/Fluxbox#fbprocmenu</a></p>
 <p><strong>fbrun</strong><br />a tiny window to launch apps from. You may want something like this in your key file (e.g. Ctrl-Alt-R = &quot;Run&quot;): Mod1 Control R :ExecCommand fbrun</p>
-<p><strong>fbsetbg</strong><br />a wrapperscript that helps setting the background. It comes with fluxbox. Read the wiki for more information: <a href="http://fluxbox-wiki.org/index.php/Howto_set_the_background">http://fluxbox-wiki.org/index.php/Howto_set_the_background</a> .</p>
+<p><strong>fbsetbg</strong><br />a wrapperscript that helps setting the background. It comes with fluxbox. Read the wiki for more information: <a href="http://fluxbox-wiki.github.io/index.php/Howto_set_the_background">http://fluxbox-wiki.github.io/index.php/Howto_set_the_background</a> .</p>
 <p><strong>fbsetbg error</strong><br />the lastwallpaper format for fbsetbg has just been updated. please remove .fluxbox/lastwallpaper and try again.</p>
-<p><strong>fedora</strong><br />to install the latest rpm for fedora first try &quot;yum install fluxbox&quot; you might also try looking at: <a href="http://fluxbox-wiki.org/index.php?title=Packages">http://fluxbox-wiki.org/index.php?title=Packages</a> for fluxbox svn builds packaged by our own errr</p>
+<p><strong>fedora</strong><br />to install the latest rpm for fedora first try &quot;yum install fluxbox&quot; you might also try looking at: <a href="http://fluxbox-wiki.github.io/index.php?title=Packages">http://fluxbox-wiki.github.io/index.php?title=Packages</a> for fluxbox svn builds packaged by our own errr</p>
 <p><strong>feh</strong><br />another wallpapersetter with transparency-compatibilty for fluxbox, get it at <a href="http://www.linuxbrit.co.uk/feh/">http://www.linuxbrit.co.uk/feh/</a></p>
 <p><strong>ffs</strong><br />go funking funk a smurf</p>
-<p><strong>files</strong><br />For an overview about the ~/.fluxbox/ structure look at <a href="http://fluxbox-wiki.org/index.php?title=Configuration_files">http://fluxbox-wiki.org/index.php?title=Configuration_files</a></p>
+<p><strong>files</strong><br />For an overview about the ~/.fluxbox/ structure look at <a href="http://fluxbox-wiki.github.io/index.php?title=Configuration_files">http://fluxbox-wiki.github.io/index.php?title=Configuration_files</a></p>
 <p><strong>firefox</strong><br />some users seem to have HUGE FONTS with firefox inside fluxbox. thats not a fluxbox-problem-bug-whatever-you-call-it. try this hint: <a href="http://www.linuxquestions.org/questions/history/213386">http://www.linuxquestions.org/questions/history/213386</a></p>
 <p><strong>flood</strong><br />to show us some tracebacks, longer parts of text or whatever could be called &quot;flood&quot; .. do us a favour and go to <a href="http://fluxbox.pastebin.ca/">http://fluxbox.pastebin.ca/</a> | <a href="http://paste.pocoo.org/">http://paste.pocoo.org/</a> | <a href="http://ompldr.org/paste">http://ompldr.org/paste</a> | #flood</p>
-<p><strong>fluxMenu</strong><br />fluxmenu is a grahical menu editor written in python using pygtk and glade, wirtten by our own Zan <a href="http://fluxbox-wiki.org/index.php/Howto_fluxmenu">http://fluxbox-wiki.org/index.php/Howto_fluxmenu</a></p>
+<p><strong>fluxMenu</strong><br />fluxmenu is a grahical menu editor written in python using pygtk and glade, wirtten by our own Zan <a href="http://fluxbox-wiki.github.io/index.php/Howto_fluxmenu">http://fluxbox-wiki.github.io/index.php/Howto_fluxmenu</a></p>
 <p><strong>fluxbox</strong><br />a powerful but slim and fast window-manager based on the original blackbox. check the /topic for all the latest news.</p>
 <p><strong>fluxbox in freebsd</strong><br />even the 0.9.4 release is in the freebsd portage tree -&gt; /usr/ports/x11-wm/fluxbox-devel.</p>
 <p><strong>fluxbox on freebsd</strong><br />the stable fluxbox version (0.1.14) lays in the ports directory /usr/ports/x11-wm/fluxbox, the development version (currently 0.9.8) lays in the directory /usr/ports/x11-wm/fluxbox-devel of the ports-tree.</p>
@@ -166,8 +166,8 @@
 <p><strong>fluxspace</strong><br />fluxspace enhances fluxbox with some new desktopmanagment capabilities, could be found <a href="http://fluxspace.sourceforge.net">http://fluxspace.sourceforge.net</a></p>
 <p><strong>fluxter</strong><br />a pager, available at <a href="http://www.isomedia.com/homes/stevencooper">http://www.isomedia.com/homes/stevencooper</a>. but be aware, <who>, it has some memoryleak issues which will eat up your memory over the time.</p>
 <p><strong>fm</strong><br /><a href="http://www.freshmeat.net">http://www.freshmeat.net</a></p>
-<p><strong>focushidden</strong><br />to remove a program from the alt-tab list, you will need to use [FocusHidden] {yes} in the apps file; learn more about the apps file at <a href="http://fluxbox-wiki.org/index.php/Howto_edit_the_apps_file">http://fluxbox-wiki.org/index.php/Howto_edit_the_apps_file</a> .</p>
-<p><strong>font</strong><br />To find out how to change font in your style see <a href="http://fluxbox-wiki.org/index.php?title=Change_font">http://fluxbox-wiki.org/index.php?title=Change_font</a> , if you have problems installing fonts or getting them to work, you should read <a href="http://fluxbox-wiki.org/index.php?title=Install_fonts">http://fluxbox-wiki.org/index.php?title=Install_fonts</a> , <a href="http://xfree.org/4.8.0/fonts2.html">http://xfree.org/4.8.0/fonts2.html</a> , <a href="https://wiki.archlinux.org/index.php/Font_Configuration">https://wiki.archlinux.org/index.php/Font_Configuration</a></p>
+<p><strong>focushidden</strong><br />to remove a program from the alt-tab list, you will need to use [FocusHidden] {yes} in the apps file; learn more about the apps file at <a href="http://fluxbox-wiki.github.io/index.php/Howto_edit_the_apps_file">http://fluxbox-wiki.github.io/index.php/Howto_edit_the_apps_file</a> .</p>
+<p><strong>font</strong><br />To find out how to change font in your style see <a href="http://fluxbox-wiki.github.io/index.php?title=Change_font">http://fluxbox-wiki.github.io/index.php?title=Change_font</a> , if you have problems installing fonts or getting them to work, you should read <a href="http://fluxbox-wiki.github.io/index.php?title=Install_fonts">http://fluxbox-wiki.github.io/index.php?title=Install_fonts</a> , <a href="http://xfree.org/4.8.0/fonts2.html">http://xfree.org/4.8.0/fonts2.html</a> , <a href="https://wiki.archlinux.org/index.php/Font_Configuration">https://wiki.archlinux.org/index.php/Font_Configuration</a></p>
 <p><strong>foo</strong><br />foo is ba</p>
 <p><strong>freebsd</strong><br />even the 0.9.4 release is in the freebsd ports tree -&gt; /usr/ports/x11-wm/fluxbox-devel.</p>
 <p><strong>excuse</strong><br />Fatal error right in front of screen</p>
@@ -175,7 +175,7 @@
 <p><strong>gcolor</strong><br />gcolor is a simple color selector with a GTk2 interface, get it here <a href="http://gcolor2.sourceforge.net/">http://gcolor2.sourceforge.net/</a></p>
 <p><strong>gday</strong><br />g'day, mate. How's it goin</p>
 <p><strong>gdesklets</strong><br />a nice little desktop app that allows you to configure various widgets. go here: <a href="http://gdesklets.gnomedesktop.org">http://gdesklets.gnomedesktop.org</a></p>
-<p><strong>gdm</strong><br /><a href="http://fluxbox-wiki.org/index.php?title=Howto_add_fluxbox_to_gdm">http://fluxbox-wiki.org/index.php?title=Howto_add_fluxbox_to_gdm</a></p>
+<p><strong>gdm</strong><br /><a href="http://fluxbox-wiki.github.io/index.php?title=Howto_add_fluxbox_to_gdm">http://fluxbox-wiki.github.io/index.php?title=Howto_add_fluxbox_to_gdm</a></p>
 <p><strong>gentoo</strong><br />gentoo is genshmoo or gentoops</p>
 <p><strong>german</strong><br />purest evil</p>
 <p><strong>giblet</strong><br />daddy!</p>
@@ -189,7 +189,7 @@
 <p><strong>groups</strong><br />don't use groups; it's deprecated, likely to be removed whenever the devs feel like it, and is technically inferior to the apps file in every way</p>
 <p><strong>grub</strong><br />yum yum</p>
 <p><strong>gtfo</strong><br />get the funk on</p>
-<p><strong>gtk</strong><br />to change your gtk theme, see <a href="http://fluxbox-wiki.org/index.php?title=Using_gtk_themes">http://fluxbox-wiki.org/index.php?title=Using_gtk_themes</a></p>
+<p><strong>gtk</strong><br />to change your gtk theme, see <a href="http://fluxbox-wiki.github.io/index.php?title=Using_gtk_themes">http://fluxbox-wiki.github.io/index.php?title=Using_gtk_themes</a></p>
 <p><strong>hacker</strong><br />yes, yes i am.</p>
 <p><strong>han</strong><br />he changes his backgrounds as often as the day has hours&lt;=or=&gt;<reply> is the master of fbsetbg and all other evil scripts&lt;=or=&gt;<reply> han has some difficulties to enter the ' so i _had_ to learn the , and the ! too .. damn him.</p>
 <p><strong>hankeys</strong><br />short for handkerchiefs</p>
@@ -201,9 +201,9 @@
 <p><strong>how are you</strong><br />My logic and cognitive functions are normal.</p>
 <p><strong>how long until ...</strong><br />that [....] long ! :) dont ask!</p>
 <p><strong>how to ask</strong><br /><a href="http://www.catb.org/~esr/faqs/smart-questions.html#intro">http://www.catb.org/~esr/faqs/smart-questions.html#intro</a></p>
-<p><strong>how to group apps</strong><br />read the docs carefully <who> short version: xprop for wm_name and group them together in the apps file ~/.fluxbox/apps see: <a href="http://fluxbox-wiki.org/index.php/Howto_edit_the_apps_file#Grouping_apps_via_the_apps_file">http://fluxbox-wiki.org/index.php/Howto_edit_the_apps_file#Grouping_apps_via_the_apps_file</a> for more info</p>
-<p><strong>how to install fonts</strong><br />if you have problems installing fonts or getting them to work, you should read the wiki at <a href="http://fluxbox-wiki.org/index.php?title=Install_fonts">http://fluxbox-wiki.org/index.php?title=Install_fonts</a> and the docs page at <a href="http://xfree.org/4.8.0/fonts2.html">http://xfree.org/4.8.0/fonts2.html</a></p>
-<p><strong>how to install styles</strong><br />see <a href="http://fluxbox-wiki.org/index.php?title=Styles">http://fluxbox-wiki.org/index.php?title=Styles</a></p>
+<p><strong>how to group apps</strong><br />read the docs carefully <who> short version: xprop for wm_name and group them together in the apps file ~/.fluxbox/apps see: <a href="http://fluxbox-wiki.github.io/index.php/Howto_edit_the_apps_file#Grouping_apps_via_the_apps_file">http://fluxbox-wiki.github.io/index.php/Howto_edit_the_apps_file#Grouping_apps_via_the_apps_file</a> for more info</p>
+<p><strong>how to install fonts</strong><br />if you have problems installing fonts or getting them to work, you should read the wiki at <a href="http://fluxbox-wiki.github.io/index.php?title=Install_fonts">http://fluxbox-wiki.github.io/index.php?title=Install_fonts</a> and the docs page at <a href="http://xfree.org/4.8.0/fonts2.html">http://xfree.org/4.8.0/fonts2.html</a></p>
+<p><strong>how to install styles</strong><br />see <a href="http://fluxbox-wiki.github.io/index.php?title=Styles">http://fluxbox-wiki.github.io/index.php?title=Styles</a></p>
 <p><strong>how to make styles</strong><br />go read tenner's style howto at <a href="http://tenr.de/howto/style_fluxbox/style_fluxbox.html">http://tenr.de/howto/style_fluxbox/style_fluxbox.html</a> or read the man page at 'man fluxbox-style'</p>
 <p><strong>how to make themes</strong><br />read 'man fluxbox-style' and take one of the default-themes to learn and see, how things are setup. play a bit around. thats all the magic.</p>
 <p><strong>how to patch</strong><br />take a looooong look at <a href="http://www.cpqlinux.com/patch.html">http://www.cpqlinux.com/patch.html</a> to learn howto patch :)</p>
@@ -211,13 +211,13 @@
 <p><strong>how to screenshot</strong><br />howto make screenshots is explained on <a href="http://www.saragossa.net/linux-tips/pages.php?subj=Capturing+Screen+Shots">http://www.saragossa.net/linux-tips/pages.php?subj=Capturing+Screen+Shots</a></p>
 <p><strong>how to set window-properties</strong><br />one could set windowproperties by 3 different ways: 1. define at startup, eg xterm -geometry 10x50 2. using the application-setting-mechanism of fluxbox, read the manpage, chapter applications settings for more information. 3. setting it after creation by using &quot;xwit&quot;, available at <a href="ftp://ftp.x.org/contrib/utilities/xwit-3.4.tar.gz">ftp://ftp.x.org/contrib/utilities/xwit-3.4.tar.gz</a> .</p>
 <p><strong>how to set windowproperties</strong><br />one could set windowproperties by 3 different ways: 1. define at startup, eg xterm -geometry 10x50 2. using the application-setting-mechanism of fluxbox, read the manpage, chapter applications settings for more information. 3. setting it after creation by using &quot;xwit&quot;, available at <a href="ftp://ftp.x.org/contrib/utilities/xwit-3.4.tar.gz">ftp://ftp.x.org/contrib/utilities/xwit-3.4.tar.gz</a> .</p>
-<p><strong>howto</strong><br />check <a href="http://fluxbox-wiki.org/index.php/Category:Howtos">http://fluxbox-wiki.org/index.php/Category:Howtos</a></p>
-<p><strong>howto round corners</strong><br /><a href="http://fluxbox-wiki.org/index.php/Howto_rounded_corners">http://fluxbox-wiki.org/index.php/Howto_rounded_corners</a></p>
+<p><strong>howto</strong><br />check <a href="http://fluxbox-wiki.github.io/index.php/Category:Howtos">http://fluxbox-wiki.github.io/index.php/Category:Howtos</a></p>
+<p><strong>howto round corners</strong><br /><a href="http://fluxbox-wiki.github.io/index.php/Howto_rounded_corners">http://fluxbox-wiki.github.io/index.php/Howto_rounded_corners</a></p>
 <p><strong>human error</strong><br />No human would be that stupid. My best guess is that a cabbage got access to your computer.</p>
 <p><strong>iconbar</strong><br />To change iconbar settings: config menu -&gt; toolbar -&gt; iconbar</p>
 <p><strong>icons</strong><br />icons for fluxbox: <a href="http://wm-icons.sourceforge.net/">http://wm-icons.sourceforge.net/</a> | <a href="http://www.linux.gr/logos/iconstore/">http://www.linux.gr/logos/iconstore/</a> | customize.org and, of course, google.com</p>
 <p><strong>icons on the desktop</strong><br />If you want icons on your desktop take a look at idesk, Rox-Filer, or fbdesk</p>
-<p><strong>idesk</strong><br />idesk is an application which drops icons onto your desktop. Check <a href="http://fluxbox-wiki.org/index.php?title=Idesk">http://fluxbox-wiki.org/index.php?title=Idesk</a> for a tutorial and <a href="http://sourceforge.net/projects/idesk/">http://sourceforge.net/projects/idesk/</a> for more info. maybe that one too: <a href="http://idesklinker.sourceforge.net/">http://idesklinker.sourceforge.net/</a></p>
+<p><strong>idesk</strong><br />idesk is an application which drops icons onto your desktop. Check <a href="http://fluxbox-wiki.github.io/index.php?title=Idesk">http://fluxbox-wiki.github.io/index.php?title=Idesk</a> for a tutorial and <a href="http://sourceforge.net/projects/idesk/">http://sourceforge.net/projects/idesk/</a> for more info. maybe that one too: <a href="http://idesklinker.sourceforge.net/">http://idesklinker.sourceforge.net/</a></p>
 <p><strong>idiot</strong><br /><a href="http://piv.pivpiv.dk/">http://piv.pivpiv.dk/</a></p>
 <p><strong>If this</strong><br />your nickname, type /msg NickServ IDENTIFY <password></p>
 <p><strong>ikaro</strong><br />ikaro was last seen Sat Feb 19 01:13:16 CET 1985 saying &quot;edit the theme and change the font size&quot;</p>
@@ -226,11 +226,11 @@
 <p><strong>imlib2</strong><br />the lib you need to have when you want to use .png .jpg and otheir formats, inside of fluxbox (in the style or the menu). To get it you have to recompile fluxbox, and remember to ./configure --enable-imlib2 (or get a package that has it enabled). You can check if you already have with it `fluxbox -i` (if its not there at all, then you need a newer version of fluxbox).</p>
 <p><strong>import</strong><br />The magic almighty &quot;import&quot; command is part of ImageMagick. To take a screenshot with it, try 'import -w root screen.jpg'.</p>
 <p><strong>in fluxbox</strong><br />there is nothing in fluxbox -- that's the whole point; you will need to find those programs yourself, with the help of google</p>
-<p><strong>init</strong><br />~/.fluxbox/init is the main configuration file, check `man fluxbox' section /resource file or <a href="http://fluxbox-wiki.org/index.php/Howto_edit_the_init_file">http://fluxbox-wiki.org/index.php/Howto_edit_the_init_file</a></p>
+<p><strong>init</strong><br />~/.fluxbox/init is the main configuration file, check `man fluxbox' section /resource file or <a href="http://fluxbox-wiki.github.io/index.php/Howto_edit_the_init_file">http://fluxbox-wiki.github.io/index.php/Howto_edit_the_init_file</a></p>
 <p><strong>ipager</strong><br />a nice little pager, with nifty eyecandy. works with a current version of fluxbox - but be warned: its still under development. details are at: <a href="http://www.useperl.ru/ipager/index.en.html">http://www.useperl.ru/ipager/index.en.html</a></p>
 <p><strong>k3b</strong><br />coolest ripware ever seen</p>
 <p><strong>keybinds</strong><br />to define keybindings allows you to control pretty much of fluxbox. check the docs about how to do this.</p>
-<p><strong>keys</strong><br />read the wiki at <a href="http://fluxbox-wiki.org/index.php/Keyboard_shortcuts">http://fluxbox-wiki.org/index.php/Keyboard_shortcuts</a> | if your keybindings aren't working, make sure the line session.keyFile in your init file points to ~/.fluxbox/keys; if your mouse buttons aren't working, try moving your keys file and restarting fluxbox</p>
+<p><strong>keys</strong><br />read the wiki at <a href="http://fluxbox-wiki.github.io/index.php/Keyboard_shortcuts">http://fluxbox-wiki.github.io/index.php/Keyboard_shortcuts</a> | if your keybindings aren't working, make sure the line session.keyFile in your init file points to ~/.fluxbox/keys; if your mouse buttons aren't working, try moving your keys file and restarting fluxbox</p>
 <p><strong>keysymdb</strong><br />view /usr/X11R6/lib/X11/XKeysymDB for a list of available key-names</p>
 <p><strong>klowner</strong><br />the dude with the wallpapers :) check out <a href="http://www.dugnet.com/klown/wallpaper/">http://www.dugnet.com/klown/wallpaper/</a></p>
 <p><strong>koko</strong><br />that's what aleczapka says when he means it's ok. do you believe him? ;)</p>
@@ -252,9 +252,9 @@
 <p><strong>_markt</strong><br />not to be trusted</p>
 <p><strong>mathias</strong><br />ak|ra (yes really)</p>
 <p><strong>Meltir</strong><br />Meltir is just plain evil. avoiding him is no longer an issue.</p>
-<p><strong>menu</strong><br />To customize the menu and learn to work with it, check out 'man fluxbox-menu' or this article from the ever-helpful wiki: <a href="http://fluxbox-wiki.org/index.php/Howto_edit_menu">http://fluxbox-wiki.org/index.php/Howto_edit_menu</a></p>
+<p><strong>menu</strong><br />To customize the menu and learn to work with it, check out 'man fluxbox-menu' or this article from the ever-helpful wiki: <a href="http://fluxbox-wiki.github.io/index.php/Howto_edit_menu">http://fluxbox-wiki.github.io/index.php/Howto_edit_menu</a></p>
 <p><strong>mit3z</strong><br />Dude, mit3z is a really poor guy. He has no karma at all.</p>
-<p><strong>mod4</strong><br />the &quot;evil&quot; windoze-key is called mod4. in xev it is displayed as Super_L and Super_R (or Hyper_[LR]). xmodmap -pm displays some more info. add: option &quot;xkbmodel&quot; &quot;pc105&quot; to your /etc/X11/XF86Config file, in the keyboard input device section. or <a href="http://fluxbox-wiki.org/index.php/Howto_mod4">http://fluxbox-wiki.org/index.php/Howto_mod4</a></p>
+<p><strong>mod4</strong><br />the &quot;evil&quot; windoze-key is called mod4. in xev it is displayed as Super_L and Super_R (or Hyper_[LR]). xmodmap -pm displays some more info. add: option &quot;xkbmodel&quot; &quot;pc105&quot; to your /etc/X11/XF86Config file, in the keyboard input device section. or <a href="http://fluxbox-wiki.github.io/index.php/Howto_mod4">http://fluxbox-wiki.github.io/index.php/Howto_mod4</a></p>
 <p><strong>moin</strong><br />if you ever wonder wtf *moin* means, visit <a href="http://moinmo.in/MoinMoinEtymology">http://moinmo.in/MoinMoinEtymology</a> ... moin!</p>
 <p><strong>mojn</strong><br />mojn mojn <who>, slept well ? :)</p>
 <p><strong>morning</strong><br />the time for all hackers to go to bed</p>
@@ -266,14 +266,14 @@
 <p><strong>newman</strong><br />for the latest fluxbox documentation please check <a href="http://fluxbox.org/help/">http://fluxbox.org/help/</a></p>
 <p><strong>no latest</strong><br />it's not very interesting to report problems in previous dev-releases. please get <a href="http://fluxbox.org/download/fluxbox-current-cvs.tar.gz">http://fluxbox.org/download/fluxbox-current-cvs.tar.gz</a> or even better get svn (ask me about 'svn')</p>
 <p><strong>no middle mousebutton</strong><br />i you are a poor guy, <who>, then you could use the emulated middle mousebutton, which is left-and-right pressed together</p>
-<p><strong>nodecor</strong><br />to get rid of borders, titlebars or other things add an entry to (fluxbox-0.9.x-versions) ~/.fluxbox/apps eg &quot;&quot;[app] (aterm)\n [Deco] {NONE}\n[end]&quot; (\n == newline), or see ,decor for temporary borderless. you can also refer to the docs or the Changelog or <a href="http://fluxbox-wiki.org/index.php/Borderless_windows">http://fluxbox-wiki.org/index.php/Borderless_windows</a></p>
+<p><strong>nodecor</strong><br />to get rid of borders, titlebars or other things add an entry to (fluxbox-0.9.x-versions) ~/.fluxbox/apps eg &quot;&quot;[app] (aterm)\n [Deco] {NONE}\n[end]&quot; (\n == newline), or see ,decor for temporary borderless. you can also refer to the docs or the Changelog or <a href="http://fluxbox-wiki.github.io/index.php/Borderless_windows">http://fluxbox-wiki.github.io/index.php/Borderless_windows</a></p>
 <p><strong>nopaste</strong><br />look for &gt;paste&lt;</p>
 <p><strong>nortfm</strong><br />you just asked a question which is not documented in our fine documentation. please consult it anyway. let us know if you really get stuck.</p>
 <p><strong>not yet. i started my new job today? time</strong><br />rare atm :)</p>
 <p><strong>offended</strong><br /><who> is offended!</p>
 <p><strong>old tabs</strong><br />some dudes out there like the old way of how tabs were realized in fluxbox. well, from version 0.9.x the tabs are included in the titlebar and there is (so far) no way to get them out of that prison.</p>
 <p><strong>openoffice</strong><br />try export OOO_FORCE_DESKTOP=gnome then start open office, if you like this you can add export OOO_FORCE_DESKTOP=gnome to your startup file for fluxbox or your shellrc</p>
-<p><strong>overlay</strong><br />For information on the overlay file please check out: <a href="http://fluxbox-wiki.org/index.php/Overlay">http://fluxbox-wiki.org/index.php/Overlay</a></p>
+<p><strong>overlay</strong><br />For information on the overlay file please check out: <a href="http://fluxbox-wiki.github.io/index.php/Overlay">http://fluxbox-wiki.github.io/index.php/Overlay</a></p>
 <p><strong>pager</strong><br />Get fbpager from <a href="http://old.fluxbox.org/fbpager/">http://old.fluxbox.org/fbpager/</a></p>
 <p><strong>party</strong><br />Ohhhhhh...shut up <who>, i still can't see straight. i'll never drink again.</p>
 <p><strong>paste</strong><br />don't flood the channel with pasted text! If it's less than four lines it's ok. For more, use one of these pages: <a href="http://fluxbox.pastebin.ca/">http://fluxbox.pastebin.ca/</a> <a href="http://paste.pocoo.org/">http://paste.pocoo.org/</a> <a href="http://ompldr.org/paste">http://ompldr.org/paste</a></p>
@@ -327,7 +327,7 @@
 <p><strong>samba</strong><br />go to <a href="http://www.samba.org">http://www.samba.org</a></p>
 <p><strong>scons</strong><br />an alternative to the autotools, based on python. Utterly nifty. ak|ra is making it happen.</p>
 <p><strong>screens</strong><br />multiple screens are multiple physical monitors. you can combine several monitors into a single &quot;screen&quot; using xinerama. don't confuse x screens with fluxbox's virtual workspaces.</p>
-<p><strong>screensaver</strong><br />if you want to start some screensavers see <a href="http://fluxbox-wiki.org/index.php?title=Screensaver">http://fluxbox-wiki.org/index.php?title=Screensaver</a></p>
+<p><strong>screensaver</strong><br />if you want to start some screensavers see <a href="http://fluxbox-wiki.github.io/index.php?title=Screensaver">http://fluxbox-wiki.github.io/index.php?title=Screensaver</a></p>
 <p><strong>screenshot</strong><br />To take a screenshot you have several options: &quot;xwd&quot;, &quot;import&quot; (from imagemagick), &quot;the gimp&quot;, &quot;scrot&quot;, &quot;ksnapshot&quot;, &quot;GkrellShoot&quot;.</p>
 <p><strong>scrot</strong><br />one way to take a screenshot is to install &quot;scrot&quot; from <a href="http://freshmeat.net/projects/scrot">http://freshmeat.net/projects/scrot</a> and do something like scrot -s -q 75 'shot-%Y-%m-%d-%H%M%S-$w-$h.jpg' .</p>
 <p><strong>sessions</strong><br />ask me about 'startfluxbox'</p>
@@ -338,19 +338,19 @@
 <p><strong>shoot</strong><br />being able to describe your problem is half the solution. try asking a question that will result in the answer you are looking for and not in yes or no.&lt;=or=&gt;peng peng you are dead.</p>
 <p><strong>short fbgm</strong><br />in #fluxbox we use the short term fbgm when we talk about the fluxbox-generate_menu script.</p>
 <p><strong>shut up</strong><br />jaja, shut up yourself. i am here to help so if you want me to shut up i guess you want to take over my job ...</p>
-<p><strong>slit</strong><br />the slit embeddes all dockable apps (eg wmxmms) in fluxbox. its also possible to embedd gnome and kde-miniapps in the slit. The slit is invisible if empty. or <a href="http://fluxbox-wiki.org/index.php/Faqs#What_is_the_slit">http://fluxbox-wiki.org/index.php/Faqs#What_is_the_slit</a></p>
+<p><strong>slit</strong><br />the slit embeddes all dockable apps (eg wmxmms) in fluxbox. its also possible to embedd gnome and kde-miniapps in the slit. The slit is invisible if empty. or <a href="http://fluxbox-wiki.github.io/index.php/Faqs#What_is_the_slit">http://fluxbox-wiki.github.io/index.php/Faqs#What_is_the_slit</a></p>
 <p><strong>slitlist</strong><br />just to make it clear: the slitlist (~/.fluxbox/slitlist) is a file which determines the order of the programms that are in the slit, its not kind of launcherfile which automaticly lauchnes dockapps ...</p>
 <p><strong>slitlogo</strong><br />You want wmdrawer, get it from <a href="http://people.easter-eggs.org/~valos/wmdrawer/">http://people.easter-eggs.org/~valos/wmdrawer/</a> and fluxbox logo from <a href="http://old.fluxbox.org/download/propaganda/">http://old.fluxbox.org/download/propaganda/</a></p>
 <p><strong>slowstartup</strong><br />faq.php#slowstartup</p>
 <p><strong>snapping</strong><br />set session.screen0.edgeSnapThreshold in your ~/.fluxbox/init file and then reconfigure fluxbox</p>
-<p><strong>software</strong><br />A list of lightweight applications for those looking for something that is not depending by any Desktop Environment <a href="http://fluxbox-wiki.org/index.php?title=Lightweight_Applications">http://fluxbox-wiki.org/index.php?title=Lightweight_Applications</a></p>
+<p><strong>software</strong><br />A list of lightweight applications for those looking for something that is not depending by any Desktop Environment <a href="http://fluxbox-wiki.github.io/index.php?title=Lightweight_Applications">http://fluxbox-wiki.github.io/index.php?title=Lightweight_Applications</a></p>
 <p><strong>something</strong><br />oh, I dont know....you tell me.</p>
 <p><strong>sorry</strong><br />nevermind, <who></p>
 <p><strong>sound</strong><br />*beeeeeeeeeep*</p>
 <p><strong>sourcemage</strong><br />source-based linux distro - <a href="http://www.sourcemage.org">http://www.sourcemage.org</a></p>
-<p><strong>startfluxbox</strong><br />startfluxbox is one way of starting fluxbox. It runs the ~/.fluxbox/startup file. So, you can start programs that run when fluxbox starts. For details, see <a href="http://fluxbox-wiki.org/index.php/Howto_edit_the_startup_file">http://fluxbox-wiki.org/index.php/Howto_edit_the_startup_file</a></p>
-<p><strong>startup</strong><br />startup is a file generated by startfluxbox; if your programs are not starting, it's probably because you are running fluxbox instead of startfluxbox; learn more about the startup file at <a href="http://fluxbox-wiki.org/index.php?title=Editing_the_startup_file">http://fluxbox-wiki.org/index.php?title=Editing_the_startup_file</a></p>
-<p><strong>startx</strong><br />To start fluxbox from the command line with &quot;startx&quot; check <a href="http://fluxbox-wiki.org/index.php/Howto_start_fluxbox_from_the_command_line">http://fluxbox-wiki.org/index.php/Howto_start_fluxbox_from_the_command_line</a></p>
+<p><strong>startfluxbox</strong><br />startfluxbox is one way of starting fluxbox. It runs the ~/.fluxbox/startup file. So, you can start programs that run when fluxbox starts. For details, see <a href="http://fluxbox-wiki.github.io/index.php/Howto_edit_the_startup_file">http://fluxbox-wiki.github.io/index.php/Howto_edit_the_startup_file</a></p>
+<p><strong>startup</strong><br />startup is a file generated by startfluxbox; if your programs are not starting, it's probably because you are running fluxbox instead of startfluxbox; learn more about the startup file at <a href="http://fluxbox-wiki.github.io/index.php?title=Editing_the_startup_file">http://fluxbox-wiki.github.io/index.php?title=Editing_the_startup_file</a></p>
+<p><strong>startx</strong><br />To start fluxbox from the command line with &quot;startx&quot; check <a href="http://fluxbox-wiki.github.io/index.php/Howto_start_fluxbox_from_the_command_line">http://fluxbox-wiki.github.io/index.php/Howto_start_fluxbox_from_the_command_line</a></p>
 <p><strong>status</strong><br />100% CPU usage, 1% free memory</p>
 <p><strong>stfu</strong><br />shake tha funk up!!</p>
 <p><strong>sticky</strong><br />In order to make an app apear on all workspaces, one should use the icon on the window or the apps file to make it 'sticky'. More details can be found in the man and in the wiki.</p>
@@ -358,7 +358,7 @@
 <p><strong>stupid</strong><br />yep.</p>
 <p><strong>styleitems</strong><br /><a href="http://old.fluxbox.org/download/themeitems.txt">http://old.fluxbox.org/download/themeitems.txt</a></p>
 <p><strong>styles</strong><br />get fluxbox styles from <a href="http://tenr.de">http://tenr.de</a> | <a href="http://dugnet.com/klown/wallpaper/thumbs.php?dir=_themes/_fluxbox">http://dugnet.com/klown/wallpaper/thumbs.php?dir=_themes/_fluxbox</a> | <a href="http://mirror.usu.edu/mirrors/gentoo/distfiles/fluxbox-styles-fluxmod-20050128.tar.bz2">http://mirror.usu.edu/mirrors/gentoo/distfiles/fluxbox-styles-fluxmod-20050128.tar.bz2</a></p>
-<p><strong>styles wiki</strong><br />The styles wiki page is: <a href="http://www.fluxbox-wiki.org/index.php/styles">http://www.fluxbox-wiki.org/index.php/styles</a></p>
+<p><strong>styles wiki</strong><br />The styles wiki page is: <a href="http://www.fluxbox-wiki.github.io/index.php/styles">http://www.fluxbox-wiki.github.io/index.php/styles</a></p>
 <p><strong>subversion</strong><br />here: <a href="http://subversion.tigris.org/">http://subversion.tigris.org/</a></p>
 <p><strong>sucks</strong><br />oh .. i only know _1_ sucks, and that's eNTi :P</p>
 <p><strong>suse</strong><br />SuSE rpms can be found at <a href="http://replay.web.archive.org/20070810200037/http://www.buks-island.org/pub/linux/suse/"><a href="http://www.buks-island.org/pub/linux/suse/">http://www.buks-island.org/pub/linux/suse/</a></a> also tenners famous style package is there too, thanks buk when you see him</p>
@@ -371,12 +371,12 @@
 <p><strong>systemtray</strong><br />to enable the systemtray-tool add a &quot;SystemTray&quot; to your session.screen0.toolbar.tools in ~/.fluxbox/init . it will take all the applets that requests a systemtray. version 0.9.x is needed.</p>
 <p><strong>t-shirt</strong><br />Want a nice gift ? Go there: <a href="http://www.spreadshirt.com/shop.php?sid=10568">http://www.spreadshirt.com/shop.php?sid=10568</a></p>
 <p><strong>tablaunch</strong><br />tablaunch is a simple, cool-looking x application launchbar that displays user-specified applications as tabs in a border of the screen and becomes hidden after a delay. URL: <a href="http://tablaunch.sf.net">http://tablaunch.sf.net</a></p>
-<p><strong>tabs</strong><br />tabs allow you to group some windows together; use ctrl-middle_click on a window's tab (or titlebar) and drag it to another window; tabs can be shown outside the window or embedded in the titlebar, which you can configure in the menu. See <a href="http://fluxbox-wiki.org/index.php?title=Tabs">http://fluxbox-wiki.org/index.php?title=Tabs</a></p>
+<p><strong>tabs</strong><br />tabs allow you to group some windows together; use ctrl-middle_click on a window's tab (or titlebar) and drag it to another window; tabs can be shown outside the window or embedded in the titlebar, which you can configure in the menu. See <a href="http://fluxbox-wiki.github.io/index.php?title=Tabs">http://fluxbox-wiki.github.io/index.php?title=Tabs</a></p>
 <p><strong>tangent</strong><br />a girl</p>
 <p><strong>tell beli if ak|ra</strong><br />done.</p>
 <p><strong>temp mod1</strong><br />If you want to temp. disable Mod1 (so that it doesn't drag windows for instance) add two key bindings like these: <key1> :macroCmd {SetResourceValue session.useMod1 false} { restart} and <key2> :macroCmd {SetResourceValue session.useMod1 true} { restart}</p>
 <p><strong>tenner</strong><br />a magnet for people that need support. he takes american express, visa and paypal.</p>
-<p><strong>term</strong><br /><a href="http://fluxbox-wiki.org/index.php/Faqs#Which_terminal_should_I_run_in_fluxbox">http://fluxbox-wiki.org/index.php/Faqs#Which_terminal_should_I_run_in_fluxbox</a></p>
+<p><strong>term</strong><br /><a href="http://fluxbox-wiki.github.io/index.php/Faqs#Which_terminal_should_I_run_in_fluxbox">http://fluxbox-wiki.github.io/index.php/Faqs#Which_terminal_should_I_run_in_fluxbox</a></p>
 <p><strong>terminus</strong><br />you can download terminus-font from <a href="http://terminus-font.sourceforge.net/">http://terminus-font.sourceforge.net/</a> ; mandrake, openbsd, freebsd and debian have packages.</p>
 <p><strong>test</strong><br /><who> plaing with me again \?</p>
 <p><strong>thanks</strong><br />Glad i could help <who> :)</p>
@@ -396,13 +396,13 @@
 <p><strong>top</strong><br />read the /topic. you should have when you came in :p</p>
 <p><strong>torsmo</strong><br />a fine, light, cute and simple systemmonitor. Download from <a href="http://torsmo.sourceforge.net">http://torsmo.sourceforge.net</a></p>
 <p><strong>tracker</strong><br /><a href="http://sourceforge.net/tracker/?group_id=35398">http://sourceforge.net/tracker/?group_id=35398</a></p>
-<p><strong>trans</strong><br />see the wiki <a href="http://fluxbox-wiki.org/index.php/Background">http://fluxbox-wiki.org/index.php/Background</a></p>
+<p><strong>trans</strong><br />see the wiki <a href="http://fluxbox-wiki.github.io/index.php/Background">http://fluxbox-wiki.github.io/index.php/Background</a></p>
 <p><strong>trans aterm</strong><br />first read the man page, then check some ,dotfiles for .Xdefaults maybe</p>
-<p><strong>transparency</strong><br />if you're looking for real transparencies, then you need a compositing manager; see <a href="http://fluxbox-wiki.org/index.php?title=Compositing">http://fluxbox-wiki.org/index.php?title=Compositing</a></p>
+<p><strong>transparency</strong><br />if you're looking for real transparencies, then you need a compositing manager; see <a href="http://fluxbox-wiki.github.io/index.php?title=Compositing">http://fluxbox-wiki.github.io/index.php?title=Compositing</a></p>
 <p><strong>transparent menus</strong><br />to get your menus transparent, use a) fb 0.9.x, b) a wallpapersetter, that does the job right (find out more with fbsetbg -i) and 3) use the mouse, open rootmenu and click the alpha-value in the fluxbox-configure-submenu</p>
 <p><strong>transparent titlebar</strong><br />grab latests cvs-snapshot and use window.alpha: value (0-255) in your stylefile to get transparent titlebars in fluxbox too.</p>
 <p><strong>tweak</strong><br />if you have a card that can do it you can try adding `` option &quot;renderaccel&quot; &quot;1&quot; '' to the device section of your xorg.conf. you may get odd crashes though! also the slit may have odd colors.</p>
-<p><strong>ubuntu</strong><br />read how to safely update your ubuntu package <a href="http://fluxbox-wiki.org/index.php?title=Update_fluxbox#Using_Ubuntu_and_Debian">http://fluxbox-wiki.org/index.php?title=Update_fluxbox#Using_Ubuntu_and_Debian</a></p>
+<p><strong>ubuntu</strong><br />read how to safely update your ubuntu package <a href="http://fluxbox-wiki.github.io/index.php?title=Update_fluxbox#Using_Ubuntu_and_Debian">http://fluxbox-wiki.github.io/index.php?title=Update_fluxbox#Using_Ubuntu_and_Debian</a></p>
 <p><strong>urxvt</strong><br />urxvt is an rxvt clone with XFT and Unicode support <a href="http://software.schmorp.de/pkg/rxvt-unicode.html">http://software.schmorp.de/pkg/rxvt-unicode.html</a></p>
 <p><strong>usage</strong><br />if you have a question about setting the background ask me about 'background' and if you have a question about problems with mplayer type &quot;fbot, mplayer?&quot;.</p>
 <p><strong>utf</strong><br />if you want to try utf8 put this command in your .xinitrc or .fluxbox/startup: export LC_ALL=nl_NL.UTF-8</p>
@@ -440,8 +440,8 @@
 <p><strong>work</strong><br />that is how you get money</p>
 <p><strong>workspaces</strong><br />virtual desktops, handled from fluxbox. dont mix them up with real &quot;screens&quot; or even &quot;servers&quot;!!</p>
 <p><strong>wtf</strong><br />werk tha funk</p>
-<p><strong>xdefaults</strong><br />a configuration file that your terminal emulator (and many other X applications) will use for settings, see <a href="http://fluxbox-wiki.org/index.php?title=Xdefaults_setup">http://fluxbox-wiki.org/index.php?title=Xdefaults_setup</a></p>
-<p><strong>xdm</strong><br />Please check the wiki at <a href="http://fluxbox-wiki.org/index.php/XDM">http://fluxbox-wiki.org/index.php/XDM</a> and make sure you have xdm set up correctly</p>
+<p><strong>xdefaults</strong><br />a configuration file that your terminal emulator (and many other X applications) will use for settings, see <a href="http://fluxbox-wiki.github.io/index.php?title=Xdefaults_setup">http://fluxbox-wiki.github.io/index.php?title=Xdefaults_setup</a></p>
+<p><strong>xdm</strong><br />Please check the wiki at <a href="http://fluxbox-wiki.github.io/index.php/XDM">http://fluxbox-wiki.github.io/index.php/XDM</a> and make sure you have xdm set up correctly</p>
 <p><strong>xev</strong><br />you can use xev to find out the names of keys -- just run the program from a terminal, press the key, and you will see a lot of output, including something like &quot;keycode 65 (keysym 0x20, space)&quot;. `space' is the name of the key</p>
 <p><strong>xft</strong><br />got xft problems? perhaps try reading: <a href="http://replay.web.archive.org/20041118225058/http://www.cse.unsw.edu.au/~simonb/fluxbox/fonts_log.txt"><a href="http://www.cse.unsw.edu.au/~simonb/fluxbox/fonts_log.txt">http://www.cse.unsw.edu.au/~simonb/fluxbox/fonts_log.txt</a></a></p>
 <p><strong>xgl</strong><br />read this <a href="http://old-en.opensuse.org/Xgl">http://old-en.opensuse.org/Xgl</a></p>

--- a/category/howtos/en/How_to_work_the_bots.html
+++ b/category/howtos/en/How_to_work_the_bots.html
@@ -22,9 +22,9 @@
 <p><code> fb0t: keyword search background</code></p>
 <p>and fbot will give you a list of keywords with 'background' in their name. Additionally you can address the bots in a private message.</p>
 <h3 id="broken-links-or-out-of-date-info">Broken links or Out of date Info</h3>
-<p>If something fbot or computer tells you is a broken or dead link, or the info is just totally wrong, please inform someone in the room who can correct it; like errr, hnaz, dopey, meltir, or one of the <a href="http://fluxbox-wiki.org/index.php/Faqs#Who_are_the_developers">developers</a></p>
+<p>If something fbot or computer tells you is a broken or dead link, or the info is just totally wrong, please inform someone in the room who can correct it; like errr, hnaz, dopey, meltir, or one of the <a href="http://fluxbox-wiki.github.io/index.php/Faqs#Who_are_the_developers">developers</a></p>
 <h3 id="factoids">Factoids</h3>
-<p>See the <a href="http://fluxbox-wiki.org/index.php?title=How_to_work_the_bots/Factoids">factoids</a> page for the whole list of fbot's keywords!</p>
+<p>See the <a href="http://fluxbox-wiki.github.io/index.php?title=How_to_work_the_bots/Factoids">factoids</a> page for the whole list of fbot's keywords!</p>
 <p><a href="/category/howtos/en/index.html">Category:English howtos</a></p>
 </body>
 </html>

--- a/category/howtos/en/Install_fonts.html
+++ b/category/howtos/en/Install_fonts.html
@@ -34,7 +34,7 @@
 <p>The artwiz fonts are not scalable, that means that its size its FIXED . Scalable fonts cant be used in terminals, although xterm supports AA, you will end up with a terminal with _huge_ fonts, and that doesn't look so good. You can try it your self with : <strong>aterm -fn verdana</strong> and then try again with 'aterm -fn nu' See the difference ?</p>
 <p><strong>Originally published by ikaro on fluxmod.dk</strong></p>
 <h2 id="see-also">See also</h2>
-<p><a href="http://fluxbox-wiki.org/index.php?title=Using_gtk_themes">How to change your GTK theme, font, icon theme</a></p>
+<p><a href="http://fluxbox-wiki.github.io/index.php?title=Using_gtk_themes">How to change your GTK theme, font, icon theme</a></p>
 <p><a href="/category/howtos/en/index.html">Category:English howtos</a></p>
 </body>
 </html>

--- a/category/howtos/en/Keymodes.html
+++ b/category/howtos/en/Keymodes.html
@@ -11,8 +11,8 @@
 		<title>Fluxbox Wiki : KeyModes</title>
 		<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
 		<link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-		<link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-		<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+		<link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+		<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 		<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 		<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
 	</head>
@@ -25,21 +25,21 @@
 			<!-- BEGINNING: NAV MENU -->
 			<div class="header">
 				<ul class="nav nav-pills pull-right" style="font-size:15px">
-					<li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-					<li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-					<li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+					<li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+					<li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+					<li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
 					<li><a href="#searchfield">Search</a></li>
 					<li class="dropdown, active">
 						<a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
 						<ul class="dropdown-menu" role="menu">
-							<li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-							<li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+							<li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
 						</ul>
 
 					</li>
@@ -131,7 +131,7 @@ MoveMode: Shift Right       :MoveRight 10</pre>
 		<!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
 		<div class="footer">
 			<br>
-			<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+			<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
 			<br>
 		</div>
 

--- a/category/howtos/en/Tabs.html
+++ b/category/howtos/en/Tabs.html
@@ -30,7 +30,7 @@
 <p><code>session.tabsAttachArea: Titlebar</code></p>
 <p>and apply it with &quot;reconfigure&quot; from the Configuration menu.</p>
 <h2 id="autogrouping">Autogrouping</h2>
-<p>Via <a href="http://fluxbox-wiki.org/index.php?title=Editing_the_apps_file#Grouping_apps_via_the_apps_file"><code>~/.fluxbox/apps</code></a>, windows can be grouped according to certain specific criteria.</p>
+<p>Via <a href="http://fluxbox-wiki.github.io/index.php?title=Editing_the_apps_file#Grouping_apps_via_the_apps_file"><code>~/.fluxbox/apps</code></a>, windows can be grouped according to certain specific criteria.</p>
 <p>For example, we want to group all web browsers in the current workspace and with a specific position:</p>
 <p><code>[group]  (workspace=[current])</code><br /><code> [app] (name=Navigator) (class=Iceweasel) (role=browser)</code><br /><code> [app] (name=luakit) (class=luakit)</code><br /><code> [app] (name=dillo) (class=Dillo)</code><br /><code>  [Position]    (UPPERLEFT)     {81 0}</code><br /><code>[end</code></p>
 <h2 id="style">Style</h2>

--- a/category/howtos/en/Using_git.html
+++ b/category/howtos/en/Using_git.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <ul>
-<li>Please refer to <a href="http://fluxbox-wiki.org/index.php/Git_-_using">git - using (under letter G)</a></li>
+<li>Please refer to <a href="http://fluxbox-wiki.github.io/index.php/Git_-_using">git - using (under letter G)</a></li>
 </ul>
 <p><a href="/category/howtos/en/index.html">Category:English howtos</a></p>
 </body>

--- a/category/howtos/en/Using_gtk_themes.html
+++ b/category/howtos/en/Using_gtk_themes.html
@@ -46,7 +46,7 @@
 <p><code>[settings]</code><br /><code> gtk-theme-name = Adwaita</code><br /><code> gtk-icon-theme-name = SimplyGrey</code><br /><code> gtk-fallback-icon-theme = gnome</code><br /><code> gtk-font-name = Sans 10</code><br /><code># next option is applicable only if selected theme supports it</code><br /><code> gtk-application-prefer-dark-theme = true</code><br /></p>
 <p>That's it.</p>
 <h2 id="see-also">See also</h2>
-<p><a href="http://fluxbox-wiki.org/index.php?title=Install_fonts">How to install fonts</a></p>
+<p><a href="http://fluxbox-wiki.github.io/index.php?title=Install_fonts">How to install fonts</a></p>
 <p><a href="/category/howtos/en/index.html">Category:English howtos</a></p>
 </body>
 </html>

--- a/category/howtos/en/index.html
+++ b/category/howtos/en/index.html
@@ -23,24 +23,24 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="http://www.fluxbox-wiki.org">Fluxbox Wiki</a>
+          <a class="navbar-brand" href="http://www.fluxbox-wiki.github.io">Fluxbox Wiki</a>
         </div>
         <div class="navbar-collapse collapse">
           <ul class="nav navbar-nav">
-            <li><a href="http://fluxbox-wiki.org/index.html">Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html">Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
             </li>
           </ul>

--- a/category/howtos/es/Borde_alrededor_de_las_ventanas.html
+++ b/category/howtos/es/Borde_alrededor_de_las_ventanas.html
@@ -16,7 +16,7 @@
 <h2 id="como-hacer-que-las-ventanas-no-tengan-decoraciones">Como hacer que las ventanas no tengan decoraciones</h2>
 <p>Tienes que editar el archivo <strong>~/.fluxbox/apps</strong> mientras fluxbox no esta ejecutandose. Agrega las siguiente lineas al archivo:</p>
 <p><code>  [app] (.*)</code><br /><code>     [Deco]    {BORDER}</code><br /><code>  [end]</code></p>
-<p>La próxima vez que ejecutes fluxbox, todas las ventanas van a tener solo el borde (si el estilo tiene definido un borde). Puedes cambiar el tamaño y el color del borde Lo puedes hacer globalmente usando el archivo de <a href="http://fluxbox-wiki.org/index.php/Como_style_overlay">overlay</a> o por separado en cada uno de los estilos.</p>
+<p>La próxima vez que ejecutes fluxbox, todas las ventanas van a tener solo el borde (si el estilo tiene definido un borde). Puedes cambiar el tamaño y el color del borde Lo puedes hacer globalmente usando el archivo de <a href="http://fluxbox-wiki.github.io/index.php/Como_style_overlay">overlay</a> o por separado en cada uno de los estilos.</p>
 <p>En ambos casos tenes que agregar las siguientes dos lineas al archivo apropiado:</p>
 <p><code>  window.borderWidth:   </code><numero><br /><code>  window.borderColor:   color (por ej. #009900, black, rgb:00/64/00)</code></p>
 <p>El significado debería ser obvio, el numero define el tamaño del borde en pixels, y el color el el color usado en el borde</p>

--- a/category/howtos/es/InstalaciÃ³n_y_configuraciÃ³n_de_Fluxbox_en_diferentes_distros.html
+++ b/category/howtos/es/InstalaciÃ³n_y_configuraciÃ³n_de_Fluxbox_en_diferentes_distros.html
@@ -71,7 +71,7 @@
 <ul>
 <li><strong>Iconos</strong></li>
 </ul>
-<p>Para utilizar iconos en fluxbox disponemos de dos aplicaciones: fbdesk e <a href="http://fluxbox-wiki.org/index.php/Howto_usar_idesk">Idesk</a>. Son facilmente configurables. FB trae una función, slit, la misma nos permite correr aplicaciones que pueden ser maximizadas desde el área que definamos para ella. Muchas aplicaciones pueden ser utilizadas con la opción -w como por ejemplo xmms:</p>
+<p>Para utilizar iconos en fluxbox disponemos de dos aplicaciones: fbdesk e <a href="http://fluxbox-wiki.github.io/index.php/Howto_usar_idesk">Idesk</a>. Son facilmente configurables. FB trae una función, slit, la misma nos permite correr aplicaciones que pueden ser maximizadas desde el área que definamos para ella. Muchas aplicaciones pueden ser utilizadas con la opción -w como por ejemplo xmms:</p>
 <p><code> $ wmxmms (podemos ingresarlo en el archivo startup para que se carguen con la Slit al inicio de FB)</code></p>
 <ul>
 <li><strong>Monitores de sistema</strong></li>

--- a/category/howtos/fin/index.html
+++ b/category/howtos/fin/index.html
@@ -11,8 +11,8 @@
     <title>Fluxbox Wiki</title>
 
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
   </head>
 
   <body>
@@ -20,21 +20,21 @@
  <div class="container theme-showcase" role="main">
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -109,7 +109,7 @@
  
  	<div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
     

--- a/category/howtos/it/Aggiungere_fluxbox_a_GDM.html
+++ b/category/howtos/it/Aggiungere_fluxbox_a_GDM.html
@@ -12,8 +12,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -27,21 +27,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -116,7 +116,7 @@
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/it/Cambiare_Font.html
+++ b/category/howtos/it/Cambiare_Font.html
@@ -13,8 +13,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -28,21 +28,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -177,7 +177,7 @@ Le voci possibili nel tema sono:
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/it/Cambiare_il_background.html
+++ b/category/howtos/it/Cambiare_il_background.html
@@ -11,8 +11,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -26,21 +26,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -167,7 +167,7 @@
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/it/Cambiare_risoluzione.html
+++ b/category/howtos/it/Cambiare_risoluzione.html
@@ -11,8 +11,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -26,21 +26,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -182,7 +182,7 @@ TV-1 disconnected (normal left inverted right x axis y axis)
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/it/Editare_il_menu.html
+++ b/category/howtos/it/Editare_il_menu.html
@@ -13,8 +13,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -28,21 +28,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -198,7 +198,7 @@
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/it/Editare_startup.html
+++ b/category/howtos/it/Editare_startup.html
@@ -11,8 +11,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -26,21 +26,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -108,7 +108,7 @@ emesene&amp;
 
 
 
-<p>The aim of this page is to provide a template to easily create all the pages of the website fluxbox-wiki.org with a consistent style.
+<p>The aim of this page is to provide a template to easily create all the pages of the website fluxbox-wiki.github.io with a consistent style.
 The code of this page contains all the structures that may be needed in order to write all the pages. Should that template won't be enough for your needs just post on the github project and we will endeavor to overcome every limit.
 For further help please refer to the code of this page that contains all the structures and all the comments that you may need.</p>
       
@@ -155,7 +155,7 @@ For further help please refer to the code of this page that contains all the str
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/it/Editare_windowmenu.html
+++ b/category/howtos/it/Editare_windowmenu.html
@@ -13,8 +13,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -28,21 +28,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -194,7 +194,7 @@
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/it/File_di_configurazione.html
+++ b/category/howtos/it/File_di_configurazione.html
@@ -15,8 +15,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -30,21 +30,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -166,7 +166,7 @@
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/it/File_manager.html
+++ b/category/howtos/it/File_manager.html
@@ -13,8 +13,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -28,21 +28,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -138,7 +138,7 @@
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/it/Idesk_-_icone_in_FluxBox.html
+++ b/category/howtos/it/Idesk_-_icone_in_FluxBox.html
@@ -14,8 +14,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -29,21 +29,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -206,7 +206,7 @@ idesk &amp;
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/it/Installazione_su_OpenBSD.html
+++ b/category/howtos/it/Installazione_su_OpenBSD.html
@@ -14,8 +14,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -29,21 +29,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -196,7 +196,7 @@ which $1 2&gt;&amp;1 &gt; /dev/null
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/it/KDM_aggiugere_FluxBox.html
+++ b/category/howtos/it/KDM_aggiugere_FluxBox.html
@@ -14,8 +14,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -29,21 +29,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -107,7 +107,7 @@ exec /usr/bin/fluxbox
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/it/index.html
+++ b/category/howtos/it/index.html
@@ -12,8 +12,8 @@
     <title>Fluxbox Wiki</title>
 
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
   </head>
 
   <body>
@@ -21,21 +21,21 @@
  <div class="container theme-showcase" role="main">
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -287,7 +287,7 @@
  
  	<div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/category/howtos/ko/창_테두리만_보이기.html
+++ b/category/howtos/ko/창_테두리만_보이기.html
@@ -16,7 +16,7 @@
 <p>플럭스박스를 실행하고 있지 않을 때 <strong>~/.fluxbox/apps</strong>를 수정하라. 따라서 플럭스박스를 종료하고 파일을 열어라. 아래 내용을 추가할 것:</p>
 <p><code>  [app] (.*)</code><br /><code>     [Deco]    {BORDER}</code><br /><code>  [end]</code></p>
 <p>저장하고선 플럭스박스를 다시 시작하라. 모든 유틸들이 이제 <strong>오직</strong> border만 보일 것이다.(스타일이 border를 설정했다면). 사용자가 border(테두리)의 픽셀 너비와 색깔을 바꿀 수 있다.</p>
-<p><a href="http://fluxbox-wiki.org/index.php/Howto_style_overlay">overlay 파일</a>을 사용하여 모든 스타일에 포괄적으로 적용하거나 스타일마다 각각 따로 적용한다.</p>
+<p><a href="http://fluxbox-wiki.github.io/index.php/Howto_style_overlay">overlay 파일</a>을 사용하여 모든 스타일에 포괄적으로 적용하거나 스타일마다 각각 따로 적용한다.</p>
 <p>두 경우 모두 해당 파일에 두 줄을 덧붙여야 한다:</p>
 <p><code>  window.borderWidth:   </code><int><br /><code>  window.borderColor:   color (e.g. #009900, black, rgb:00/64/00)</code></p>
 <p>의미하는 바를 쉽게 알 것이다, int값은 border의 너비 픽셀값을 정하고, color는 border의 실제 색깔이다.</p>

--- a/contribute.html
+++ b/contribute.html
@@ -12,8 +12,8 @@
     <title>Fluxbox Wiki</title>
 
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
   </head>
 
   <body>
@@ -21,21 +21,21 @@
  <div class="container theme-showcase" role="main">
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li ><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li class="active"><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li ><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li class="active"><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -95,7 +95,7 @@
  
  	<div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
     <title>Fluxbox Wiki</title>
 
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
   </head>
 
   <body>
@@ -21,21 +21,21 @@
  <div class="container theme-showcase" role="main">
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li class="active"><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li class="active"><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -105,7 +105,7 @@ The #fluxbox channel on the <a href="http://freenode.net/">Freenode</a> network 
       
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/template.html
+++ b/template.html
@@ -12,8 +12,8 @@
     <title>Fluxbox Wiki</title>
 	<!-- BEGINNING: STYLE + JAVASCRIPT FOR THE TOC -->
     <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://www.fluxbox-wiki.org/jumbotron-custom.css" rel="stylesheet">
-	<script type="text/javascript" src="http://www.fluxbox-wiki.org/generated_toc.js"></script>
+    <link href="http://www.fluxbox-wiki.github.io/jumbotron-custom.css" rel="stylesheet">
+	<script type="text/javascript" src="http://www.fluxbox-wiki.github.io/generated_toc.js"></script>
 	<!-- TOC Script from http://www.kryogenix.org/code/browser/generated-toc/ -->
 	<!-- END: STYLE + JAVASCRIPT FOR THE TOC -->
   </head>
@@ -27,21 +27,21 @@
  <!-- BEGINNING: NAV MENU -->
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown, active">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -70,7 +70,7 @@
 <h2>0. Introduction</h2><!-- EACH SECTION MUST HAVE A TITLE H2 --> 
 
 
-<p>The aim of this page is to provide a template to easily create all the pages of the website fluxbox-wiki.org with a consistent style.
+<p>The aim of this page is to provide a template to easily create all the pages of the website fluxbox-wiki.github.io with a consistent style.
 The code of this page contains all the structures that may be needed in order to write all the pages. Should that template won't be enough for your needs just post on the github project and we will endeavor to overcome every limit.
 For further help please refer to the code of this page that contains all the structures and all the comments that you may need.</p>
       
@@ -143,7 +143,7 @@ Integer porta dui id turpis venenatis, auctor tempor diam tincidunt.
 <!-- BELOW: THE SEARCH BAR AND THE SCRIPTS REQUIRED BY THE PAGE -->      
     <div class="footer">
     	<br>
-    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+    	<a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       	<br>
     </div>
 

--- a/test.html
+++ b/test.html
@@ -24,21 +24,21 @@
  <div class="container theme-showcase" role="main">
       <div class="header">
           <ul class="nav nav-pills pull-right" style="font-size:15px">
-            <li class="active"><a href="http://fluxbox-wiki.org/index.html" >Home</a></li>
-            <li><a href="http://fluxbox-wiki.org/about.html">About</a></li>
-            <li><a href="http://fluxbox-wiki.org/contribute.html">Contribute</a></li>
+            <li class="active"><a href="http://fluxbox-wiki.github.io/index.html" >Home</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/about.html">About</a></li>
+            <li><a href="http://fluxbox-wiki.github.io/contribute.html">Contribute</a></li>
             <li><a href="#searchfield">Search</a></li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Languages <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="http://fluxbox-wiki.org/category/howtos/en/index.html">English</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/it/index.html">Italian</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/de/index.html">German</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/fin/index.html">Finnish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/br/index.html">Portuguese</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ko/index.html">Korean</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/es/index.html">Spanish</a></li>
-                <li><a href="http://fluxbox-wiki.org/category/howtos/ru/index.html">Russian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/en/index.html">English</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/it/index.html">Italian</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/de/index.html">German</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/fin/index.html">Finnish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/br/index.html">Portuguese</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ko/index.html">Korean</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/es/index.html">Spanish</a></li>
+                <li><a href="http://fluxbox-wiki.github.io/category/howtos/ru/index.html">Russian</a></li>
               </ul>
 
             </li>
@@ -106,7 +106,7 @@ The #fluxbox channel on the <a href="http://freenode.net/">Freenode</a> network 
     </div> <!-- /container -->
       <div class="footer">
     <br>
-        <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.org&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
+        <a name="searchfield"> <center> <iframe src="http://duckduckgo.com/search.html?width=480&site=www.fluxbox-wiki.github.io&prefill=Fluxbox Wiki&kn=1&kj=b " style="overflow:hidden;margin:0;padding:0;width:550px;height:40px;" frameborder="0"></iframe></center></a>
       
 
       


### PR DESCRIPTION
This resolves issue #84 , and makes the wiki accessible under the generic github [url - fluxbox-wiki.github.io](http://fluxbox-wiki.github.io)  
This also updates all links to the fluxbox-wiki.org url to the generic github domain.  (this was a straightforward string replace)